### PR TITLE
Remove unlock/exclusive status for Sweet Home Party

### DIFF
--- a/src/songs/a20.json
+++ b/src/songs/a20.json
@@ -57,8 +57,6 @@
     }
   },
   {
-    "unlock": true,
-    "gold_exclusive": true,
     "name": "SWEET HOME PARTY",
     "name_translation": "",
     "jacket": "SWEET_HOME_PARTY.png",


### PR DESCRIPTION
Sweet Home Party is available by default on A20 and shouldn't be marked as unlockable or gold cab exclusive
(and I _cannot wait_ to see people pull it in a tournament)