### PR TITLE
Fix song search not populating with suggestions

### DIFF
--- a/src/draw-state.tsx
+++ b/src/draw-state.tsx
@@ -95,7 +95,7 @@ export class DrawStateManager extends Component<Props, DrawState> {
         gameData: data,
         drawings: [],
         fuzzySearch: new FuzzySearch(
-          data,
+          data.songs,
           [
             "name",
             "name_translation",


### PR DESCRIPTION
Small oversight that caused Song Search to not to populate with song options while typing.

I wasn't sure whether to add changes to omit a song suggestion entirely if none of the charts had levels > 12, so I left that aspect alone. Something like Miracle Moon for example can appear as a suggestion but has no valid charts.