### PR TITLE
Release flags for songs after release of A20

### DIFF
--- a/src/songs/a20.json
+++ b/src/songs/a20.json
@@ -2630,7 +2630,6 @@
       "jacket": "Pursuer.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "75-300",
-      "flags": ["extraExclusive"],
       "charts": [
         { "lvl": 3, "style": "single", "diffClass": "beginner" },
         { "lvl": 7, "style": "single", "diffClass": "basic" },
@@ -2650,7 +2649,6 @@
       "jacket": "Love You More.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "175",
-      "flags": ["extraExclusive"],
       "charts": [
         { "lvl": 3, "style": "single", "diffClass": "beginner" },
         { "lvl": 9, "style": "single", "diffClass": "basic" },
@@ -2884,7 +2882,6 @@
       "bpm": "160",
       "name_translation": "",
       "artist_translation": "",
-      "flags": ["extraExclusive"],
       "charts": [
         {
           "step": 459,
@@ -4306,7 +4303,6 @@
         {
           "step": 786,
           "freeze": 16,
-          "flags": ["extraExclusive"],
           "lvl": 18,
           "style": "single",
           "diffClass": "challenge"
@@ -4342,7 +4338,6 @@
         {
           "step": 765,
           "freeze": 16,
-          "flags": ["extraExclusive"],
           "lvl": 18,
           "style": "double",
           "diffClass": "challenge"

--- a/src/songs/a20.json
+++ b/src/songs/a20.json
@@ -43737,7 +43737,6 @@
       "name_translation": "",
       "jacket": "VEGA.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 459,

--- a/src/songs/a20.json
+++ b/src/songs/a20.json
@@ -2073,7 +2073,6 @@
       "name_translation": "",
       "artist_translation": "",
       "genre": "",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 4, "style": "single", "diffClass": "beginner" },
         { "lvl": 7, "style": "single", "diffClass": "basic" },
@@ -2093,7 +2092,6 @@
       "name_translation": "Schrodinger's cat",
       "artist_translation": "",
       "genre": "",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 6, "style": "single", "diffClass": "beginner" },
         { "lvl": 9, "style": "single", "diffClass": "basic" },
@@ -2134,7 +2132,6 @@
       "name_translation": "Roshin yuukai",
       "artist_translation": "",
       "genre": "",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 2, "style": "single", "diffClass": "beginner" },
         { "lvl": 6, "style": "single", "diffClass": "basic" },
@@ -2154,7 +2151,6 @@
       "name_translation": "",
       "genre": "",
       "bpm": "140",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 3, "style": "single", "diffClass": "beginner" },
         { "lvl": 6, "style": "single", "diffClass": "basic" },
@@ -2186,7 +2182,6 @@
       "name_translation": "",
       "artist_translation": "",
       "genre": "",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 9, "style": "single", "diffClass": "beginner" },
         { "lvl": 12, "style": "single", "diffClass": "basic" },
@@ -2218,7 +2213,6 @@
       "name_translation": "",
       "artist_translation": "",
       "genre": "",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 5, "style": "single", "diffClass": "beginner" },
         { "lvl": 8, "style": "single", "diffClass": "basic" },
@@ -2250,7 +2244,6 @@
       "name_translation": "",
       "artist_translation": "",
       "genre": "",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 8, "style": "single", "diffClass": "beginner" },
         { "lvl": 11, "style": "single", "diffClass": "basic" },
@@ -2284,7 +2277,6 @@
       "name_translation": "",
       "artist_translation": "BEMANI Sound Team \"TAG\" feat. Rio Hiiragi",
       "genre": "",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 3, "style": "single", "diffClass": "beginner" },
         { "lvl": 5, "style": "single", "diffClass": "basic" },
@@ -2359,7 +2351,6 @@
       "search_hint": "Fuurin hanabi",
       "folder": "DanceDanceRevolution A",
       "bpm": "150",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 2, "style": "single", "diffClass": "beginner" },
         { "lvl": 5, "style": "single", "diffClass": "basic" },
@@ -2380,7 +2371,6 @@
       "search_hint": "Seiza ga koishita shunkan wo",
       "folder": "DanceDanceRevolution A",
       "bpm": "186",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 2, "style": "single", "diffClass": "beginner" },
         { "lvl": 7, "style": "single", "diffClass": "basic" },
@@ -2431,7 +2421,6 @@
       "jacket": "SUPER SUMMER SALE.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "155",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 2, "style": "single", "diffClass": "beginner" },
         { "lvl": 8, "style": "single", "diffClass": "basic" },
@@ -2451,7 +2440,6 @@
       "jacket": "Rejoin.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "135",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 2, "style": "single", "diffClass": "beginner" },
         { "lvl": 6, "style": "single", "diffClass": "basic" },
@@ -2471,7 +2459,6 @@
       "jacket": "Puberty Dysthmia.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "70-210",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 4, "style": "single", "diffClass": "beginner" },
         { "lvl": 8, "style": "single", "diffClass": "basic" },
@@ -2491,7 +2478,6 @@
       "jacket": "Life is beautiful.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "155",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 5, "style": "single", "diffClass": "beginner" },
         { "lvl": 8, "style": "single", "diffClass": "basic" },
@@ -2511,7 +2497,6 @@
       "jacket": "Eternal Summer.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "145",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 2, "style": "single", "diffClass": "beginner" },
         { "lvl": 6, "style": "single", "diffClass": "basic" },
@@ -2531,7 +2516,6 @@
       "jacket": "ALGORITHM.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "130",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 5, "style": "single", "diffClass": "beginner" },
         { "lvl": 7, "style": "single", "diffClass": "basic" },
@@ -2551,7 +2535,6 @@
       "jacket": "Oboro (dj TAKA Remix).png",
       "folder": "DanceDanceRevolution A",
       "bpm": "149",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 3, "style": "single", "diffClass": "beginner" },
         { "lvl": 5, "style": "single", "diffClass": "basic" },
@@ -2571,7 +2554,6 @@
       "jacket": "Chronos (walk with you remix).png",
       "folder": "DanceDanceRevolution A",
       "bpm": "74-148",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 3, "style": "single", "diffClass": "beginner" },
         { "lvl": 6, "style": "single", "diffClass": "basic" },
@@ -2591,7 +2573,6 @@
       "jacket": "Sennen no kotowari.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "153",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 3, "style": "single", "diffClass": "beginner" },
         { "lvl": 6, "style": "single", "diffClass": "basic" },
@@ -2611,7 +2592,6 @@
       "jacket": "Plain Asia -PHQ remix-.png",
       "folder": "DanceDanceRevolution A",
       "bpm": "182",
-      "flags": ["unlock"],
       "charts": [
         { "lvl": 5, "style": "single", "diffClass": "beginner" },
         { "lvl": 7, "style": "single", "diffClass": "basic" },
@@ -3163,7 +3143,6 @@
       "bpm": "80-160",
       "jacket": "Shunpuu blowing wind.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 573,
@@ -3219,7 +3198,6 @@
       "bpm": "95-190",
       "jacket": "Boss Rush.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 721,
@@ -3275,7 +3253,6 @@
       "bpm": "181",
       "jacket": "Sakura Reflection.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 479,
@@ -4012,7 +3989,6 @@
       "name_translation": "",
       "jacket": "High School Love.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 121,
@@ -4074,7 +4050,6 @@
       "name_translation": "",
       "jacket": "CHOCOLATE PHILOSOPHY.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 71,
@@ -4327,7 +4302,6 @@
       "name_translation": "",
       "jacket": "ACE FOR ACES.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 786,
@@ -4405,7 +4379,6 @@
       "bpm": "110-880",
       "name_translation": "",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 925,
@@ -4953,7 +4926,6 @@
       "name_translation": "",
       "jacket": "Cosy Catastrophe.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 686,
@@ -5212,7 +5184,6 @@
       "name_translation": "",
       "jacket": "Neutrino.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 570,
@@ -5288,7 +5259,6 @@
       "name_translation": "",
       "jacket": "out of focus.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 572,
@@ -5419,7 +5389,6 @@
       "name_translation": "",
       "jacket": "Ishtar.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 481,
@@ -5497,7 +5466,6 @@
       "name_translation": "Measurement of Love",
       "jacket": "Measurement of Love.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 337,
@@ -5559,7 +5527,6 @@
       "name_translation": "LOVE IS LIKE THE SPACEWAR!",
       "jacket": "LOVE IS LIKE THE SPACEWAR!.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 739,
@@ -5635,7 +5602,6 @@
       "name_translation": "",
       "jacket": "Start a New Day.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 578,
@@ -5827,7 +5793,6 @@
       "name_translation": "",
       "jacket": "Emera.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 563,
@@ -5903,7 +5868,6 @@
       "name_translation": "",
       "jacket": "ZEPHYRANTHES.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 422,
@@ -5965,7 +5929,6 @@
       "name_translation": "",
       "jacket": "Triple Counter.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 533,
@@ -6027,7 +5990,6 @@
       "name_translation": "",
       "jacket": "StrayedCatz.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 336,
@@ -6089,7 +6051,6 @@
       "name_translation": "",
       "jacket": "Sephirot.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 346,
@@ -6151,7 +6112,6 @@
       "name_translation": "",
       "jacket": "Grand Chariot.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 383,
@@ -6213,7 +6173,6 @@
       "name_translation": "",
       "jacket": "Angelic Jelly.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 402,
@@ -6275,7 +6234,6 @@
       "name_translation": "",
       "jacket": "Far east nightbird kors k Remix -DDR edit ver-.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 312,
@@ -6337,7 +6295,6 @@
       "name_translation": "",
       "jacket": "Far east nightbird.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 327,
@@ -6393,7 +6350,6 @@
       "name_translation": "",
       "jacket": "STERLING SILVER (U1 overground mix).png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 348,
@@ -6455,7 +6411,6 @@
       "name_translation": "",
       "jacket": "STERLING SILVER.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 338,
@@ -6517,7 +6472,6 @@
       "name_translation": "",
       "jacket": "Come to Life.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 730,
@@ -6777,7 +6731,6 @@
       "name_translation": "",
       "jacket": "8000000.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 353,
@@ -7418,7 +7371,6 @@
       "name_translation": "",
       "jacket": "Adularia.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 290,
@@ -8549,7 +8501,6 @@
       "name_translation": "",
       "jacket": "Astrogazer.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 712,
@@ -9116,7 +9067,6 @@
       "search_hint": "Bakunana testroyer",
       "jacket": "Bakunana testroyer.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 391,
@@ -9366,7 +9316,6 @@
       "name_translation": "Bassdrop Freaks",
       "jacket": "Bassdrop Freaks.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 317,
@@ -9662,7 +9611,6 @@
       "name_translation": "BeBeatstream",
       "jacket": "BeBeatstream.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 348,
@@ -11934,7 +11882,6 @@
       "name_translation": "",
       "jacket": "Cleopatrysm.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 345,
@@ -12647,7 +12594,6 @@
       "name_translation": "",
       "jacket": "Cytokinesis.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 305,
@@ -12922,7 +12868,6 @@
       "name_translation": "",
       "jacket": "Daily Lunch Special.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 362,
@@ -13354,7 +13299,6 @@
       "name_translation": "",
       "jacket": "Dancer in the flare.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 239,
@@ -13651,7 +13595,6 @@
       "name_translation": "Deadball de Homerun",
       "jacket": "Deadball de Homerun.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 274,
@@ -14523,7 +14466,6 @@
       "name_translation": "Doki doki ryusei trap girl!!",
       "jacket": "Doki doki ryusei trap girl!!.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock", "tempUnlock"],
       "charts": [
         {
           "step": 324,
@@ -14673,7 +14615,6 @@
       "name_translation": "Dopamine",
       "jacket": "Dopamine.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 454,
@@ -15525,7 +15466,6 @@
       "name_translation": "",
       "jacket": "Electric Dance System Music.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 295,
@@ -15988,7 +15928,6 @@
       "name_translation": "",
       "jacket": "Engraved Mark.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 425,
@@ -17392,7 +17331,6 @@
       "name_translation": "",
       "jacket": "Follow Tomorrow.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 276,
@@ -17826,7 +17764,6 @@
       "name_translation": "FUJIMORI -MATSURI- FESTIVAL",
       "jacket": "FUJIMORI -MATSURI- FESTIVAL.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 283,
@@ -19401,7 +19338,6 @@
       "name_translation": "Happy koi lovely time!!",
       "jacket": "Happy koi lovely time!!.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 259,
@@ -20825,7 +20761,6 @@
       "name_translation": "",
       "jacket": "HYENA.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 338,
@@ -21615,7 +21550,6 @@
       "name_translation": "",
       "jacket": "Illegal Function Call.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 477,
@@ -21862,7 +21796,6 @@
       "name_translation": "",
       "jacket": "In The Breeze.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 226,
@@ -22279,7 +22212,6 @@
       "name_translation": "",
       "jacket": "IX.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 753,
@@ -22609,7 +22541,6 @@
       "name_translation": "",
       "jacket": "JOMANDA.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 644,
@@ -22971,7 +22902,6 @@
       "name_translation": "",
       "jacket": "KHAMEN BREAK.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 423,
@@ -23320,7 +23250,6 @@
       "name_translation": "Koihadou? Moro@Hadou OK☆Theory!!",
       "jacket": "Koihadou Moro Hadou OK Theory.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 363,
@@ -23376,7 +23305,6 @@
       "name_translation": "Under this blue sky",
       "jacket": "Kono aozora no shita de.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 317,
@@ -25625,7 +25553,6 @@
       "name_translation": "",
       "jacket": "MAKE A JAM!.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         { "step": 193, "lvl": 7, "style": "single", "diffClass": "difficult" },
         { "step": 240, "lvl": 9, "style": "single", "diffClass": "expert" },
@@ -27037,7 +26964,6 @@
       "name_translation": "Mind Game",
       "jacket": "Mind Game.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 338,
@@ -27794,7 +27720,6 @@
       "name_translation": "Nageki no Ki",
       "jacket": "Nageki no Ki.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 763,
@@ -27941,7 +27866,6 @@
       "name_translation": "Natsuiro DIARY -DDR mix-",
       "jacket": "Natsuiro DIARY -DDR mix-.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 389,
@@ -28217,7 +28141,6 @@
       "name_translation": "",
       "jacket": "New Century.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 669,
@@ -29039,7 +28962,6 @@
       "name_translation": "",
       "jacket": "Nostalgia Is Lost.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 386,
@@ -29824,7 +29746,6 @@
       "name_translation": "Osenju Meditation",
       "jacket": "Osenju Meditation.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 385,
@@ -30023,7 +29944,6 @@
       "name_translation": "Pa Pi Pu Yeah!",
       "jacket": "Pa Pi Pu Yeah!.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 294,
@@ -31327,7 +31247,6 @@
       "name_translation": "",
       "jacket": "Poochie.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 412,
@@ -31630,7 +31549,6 @@
       "name_translation": "",
       "jacket": "POSSESSION(EDP Live Mix).png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 445,
@@ -31993,7 +31911,6 @@
       "name_translation": "",
       "jacket": "PUNISHER.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 382,
@@ -33500,7 +33417,6 @@
       "name_translation": "",
       "jacket": "RISING FIRE HAWK.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 664,
@@ -33991,7 +33907,6 @@
       "name_translation": "",
       "jacket": "S!ck.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 372,
@@ -34468,7 +34383,6 @@
       "name_translation": "",
       "jacket": "Sakura Mirage.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 337,
@@ -35212,7 +35126,6 @@
       "name_translation": "",
       "jacket": "second spring storm.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock", "tempUnlock"],
       "charts": [
         {
           "step": 299,
@@ -37224,7 +37137,6 @@
       "name_translation": "Sora he no katamichi kippu",
       "jacket": "Sora he no katamichi kippu.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 232,
@@ -37526,7 +37438,6 @@
       "name_translation": "",
       "jacket": "Special One.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 176,
@@ -37643,7 +37554,6 @@
       "name_translation": "",
       "jacket": "Squeeze.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 272,
@@ -38338,7 +38248,6 @@
       "name_translation": "",
       "jacket": "Stella Sinistra.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 344,
@@ -39914,7 +39823,6 @@
       "name_translation": "",
       "jacket": "TECH-NOID.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 277,
@@ -40094,7 +40002,6 @@
       "name_translation": "Tenkuu no hana",
       "jacket": "Tenkuu no hana.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 344,
@@ -41310,7 +41217,6 @@
       "name_translation": "Todoroke! Koi no beanball!!",
       "jacket": "Todoroke! Koi no beanball!!.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 357,
@@ -41817,7 +41723,6 @@
       "name_translation": "Totsugeki! Glass no Nisohime!",
       "jacket": "Totsugeki! Glass no Nisohime!.png",
       "folder": "DanceDanceRevolution (2015)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 348,
@@ -41879,7 +41784,6 @@
       "name_translation": "",
       "jacket": "Towards the TOWER.png",
       "folder": "DanceDanceRevolution A",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 246,
@@ -42671,7 +42575,6 @@
       "name_translation": "",
       "jacket": "True Blue.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 380,
@@ -44965,7 +44868,6 @@
       "name_translation": "How to play baseball and its history (final version)",
       "jacket": "Yakyu no asobikata soshite sono rekishi ~ketteihan~.png",
       "folder": "DanceDanceRevolution (2014)",
-      "flags": ["unlock"],
       "charts": [
         {
           "step": 276,


### PR DESCRIPTION
A large set of charts that were unlocks in DDR Ace have now been made available by default in DDR A20. These changes are made to reflect that.

I did searches for "unlock", "tempUnlock", and "extraExclusive" and checked manually against RemyWiki to see if the unlock status had changed since A20 had released.

Some charts are still left as unlocks even with the release of A20.
- MAX 360 CSP/CDP
- Chaos Terror Tech CSP/CDP
- Possession 20th CSP/CDP
- Show Me Your Moves CSP/CDP

I feel good about this PR and trust RemyWiki but it might be helpful to get sanity checking from other people who might know the game library better than I do.