### PR TITLE
Last Golden League -> Playable by Default Song Reclassification

### DIFF
--- a/src/songs/a20plus.json
+++ b/src/songs/a20plus.json
@@ -6141,7 +6141,6 @@
       ],
       "remyLink": "http://remywiki.com/CyberConnect",
       "jacket": "CyberConnect.jpg",
-      "flags": ["goldenLeague"],
       "saHash": "1qPIiqqQo0P9dD90I11q90b0ooIidbPO",
       "saIndex": "921"
     },
@@ -7685,7 +7684,6 @@
       ],
       "remyLink": "http://remywiki.com/DIGITALIZER",
       "jacket": "DIGITALIZER.jpg",
-      "flags": ["goldenLeague"],
       "saHash": "dqQbQ9oPlIi6bDdi18d9qPlDb0PiDddi",
       "saIndex": "954"
     },
@@ -8243,7 +8241,6 @@
       ],
       "remyLink": "http://remywiki.com/Draw%20the%20Savage",
       "jacket": "Draw the Savage.jpg",
-      "flags": ["goldenLeague"],
       "saHash": "D6ll81qoDDPIq0d89O69dIQIldQdQoId",
       "saIndex": "962"
     },
@@ -12198,7 +12195,6 @@
       ],
       "remyLink": "http://remywiki.com/Going%20Hypersonic",
       "jacket": "Going Hypersonic.jpg",
-      "flags": ["goldenLeague"],
       "saHash": "6Obi001oi9Qd1966dOd6d6Qo66dbbill",
       "saIndex": "971"
     },
@@ -20197,7 +20193,6 @@
       ],
       "remyLink": "http://remywiki.com/MUTEKI%20BUFFALO",
       "jacket": "MUTEKI BUFFALO.jpg",
-      "flags": ["goldenLeague"],
       "saHash": "d10d86DQqqd6QDlQlOI1bQi9do66l8Od",
       "saIndex": "969"
     },


### PR DESCRIPTION
Removed goldenLeague flags on songs available to play on white cabs as of the current patch of A20PLUS per an observation made by an end-user.
![image](https://user-images.githubusercontent.com/107084083/177638803-290e24b0-1eeb-4fe8-a6bb-1eaaa01e76b1.png)


Note: As of June 15th, "Lightspeed" is also available on white cabs, but the cab must be on A3 in order to access it.
Source: https://remywiki.com/Lightspeed