### PR TITLE
Typo fix

### DIFF
--- a/src/drawing-list.tsx
+++ b/src/drawing-list.tsx
@@ -32,7 +32,7 @@ export function DrawingList() {
           description="Click 'Draw' above to draw some songs at random. Chose from other games in the top left menu."
           action={
             <Callout intent="primary" icon={IconNames.WRENCH}>
-              DDR Card Draw now has a new name and and URL. Look for more new
+              DDR Card Draw now has a new name and URL. Look for more new
               features coming soon!
             </Callout>
           }


### PR DESCRIPTION
Quick typo fix here
Before:
![image](https://user-images.githubusercontent.com/416477/223628412-8f76573d-082f-43df-a9f4-ac2b56b28961.png)
After:
![image](https://user-images.githubusercontent.com/416477/223628726-70f39d89-76db-4ef6-bf79-27b849eb05a6.png)

