### PR TITLE
Add option for weights on top end songs as a group

### DIFF
--- a/src/assets/i18n.json
+++ b/src/assets/i18n.json
@@ -17,6 +17,10 @@
       "check": {
         "title": "Prevents very unlikely outcomes (e.g. multiple 17s drawn when at 10% chance)",
         "label": "Force Expected Distribution"
+      },
+      "group": {
+        "title": "All charts at a this level or above will be weighted as part of a shared \"bucket\".",
+        "label": "Group top end charts starting at"
       }
     },
     "include": "Include",

--- a/src/card-draw.ts
+++ b/src/card-draw.ts
@@ -82,19 +82,25 @@ export function draw(gameData: GameData, configData: ConfigState): Drawing {
     chartCount: numChartsToRandom,
     upperBound,
     lowerBound,
-    style,
     useWeights,
     forceDistribution,
     weights,
+    groupSongsAt,
   } = configData;
 
-  const validCharts: Record<string, Array<DrawnChart>> = {};
+  /** all charts we will consider to be valid for this draw */
+  const validCharts = new Map<number, Array<DrawnChart>>();
   times(gameData.meta.lvlMax, (n) => {
-    validCharts[n.toString()] = [];
+    validCharts.set(n, []);
   });
 
   for (const chart of eligibleCharts(configData, gameData.songs)) {
-    validCharts[chart.level].push(chart);
+    let chartLevel = chart.level;
+    // merge in higher difficulty charts into a single group, if configured to do so
+    if (useWeights && groupSongsAt && groupSongsAt < chartLevel) {
+      chartLevel = groupSongsAt;
+    }
+    validCharts.get(chartLevel)!.push(chart);
   }
 
   /**
@@ -118,7 +124,7 @@ export function draw(gameData: GameData, configData: ConfigState): Drawing {
       expectedDrawPerLevel[level.toString()] = weightAmount;
       totalWeights += weightAmount;
     } else {
-      weightAmount = validCharts[level.toString()].length;
+      weightAmount = validCharts.get(level)!.length;
     }
     times(weightAmount, () => distribution.push(level));
   }
@@ -152,9 +158,12 @@ export function draw(gameData: GameData, configData: ConfigState): Drawing {
     }
 
     // first pick a difficulty
-    const chosenDifficulty =
+    let chosenDifficulty =
       distribution[Math.floor(Math.random() * distribution.length)];
-    const selectableCharts = validCharts[chosenDifficulty.toString()];
+    if (useWeights && groupSongsAt && groupSongsAt < chosenDifficulty) {
+      chosenDifficulty = groupSongsAt;
+    }
+    const selectableCharts = validCharts.get(chosenDifficulty)!;
     const randomIndex = Math.floor(Math.random() * selectableCharts.length);
     const randomChart = selectableCharts[randomIndex];
 

--- a/src/config-state.tsx
+++ b/src/config-state.tsx
@@ -7,6 +7,8 @@ export interface ConfigState {
   useWeights: boolean;
   orderByAction: boolean;
   weights: number[];
+  /** charts of this level or higher will be grouped into the same "bucket" */
+  groupSongsAt: number | null;
   forceDistribution: boolean;
   constrainPocketPicks: boolean;
   style: string;
@@ -23,6 +25,7 @@ export const useConfigState = createStore<ConfigState>((set, get) => ({
   useWeights: false,
   orderByAction: true,
   weights: [],
+  groupSongsAt: null,
   forceDistribution: true,
   constrainPocketPicks: true,
   style: "",

--- a/src/controls/controls-weights.tsx
+++ b/src/controls/controls-weights.tsx
@@ -3,7 +3,6 @@ import styles from "./controls-weights.css";
 import { times } from "../utils";
 import { useMemo, useState } from "react";
 import { useConfigState } from "../config-state";
-import {} from "../draw-state";
 import { useIntl } from "../hooks/useIntl";
 import { NumericInput, Checkbox } from "@blueprintjs/core";
 
@@ -14,6 +13,7 @@ interface Props {
 
 export function WeightsControls({ high, low }: Props) {
   const { t } = useIntl();
+  const [groupCutoff, setGroupCutoff] = useState(high - 1);
   const { weights, forceDistribution, groupSongsAt, updateConfig } =
     useConfigState(
       (cfg) => ({
@@ -28,7 +28,6 @@ export function WeightsControls({ high, low }: Props) {
     () => times(high - low + 1, (n) => n + low - 1),
     [high, low]
   );
-  const [groupCutoff, setGroupCutoff] = useState(high - 1);
 
   function toggleForceDistribution() {
     updateConfig((state) => ({


### PR DESCRIPTION
aka the andy457 memorial feature
aka the DEGRS deletion option

When using weighted distributions an additional option allows you to group high-end level charts into a single bucket:
![image](https://github.com/noahm/DDRCardDraw/assets/319485/8b30de83-6515-4edf-a4cb-95e3b824e346)

Once selected, the total number of adjustable weights is reduced to collapse the chosen levels into a single group:
![image](https://github.com/noahm/DDRCardDraw/assets/319485/5598e90e-c793-425b-906c-2e5771100628)
