### PR TITLE
Use type=number on all numeric inputs

### DIFF
--- a/src/controls/controls-weights.tsx
+++ b/src/controls/controls-weights.tsx
@@ -111,6 +111,7 @@ export function WeightsControls({ usesTiers, high, low }: Props) {
       {groups.map((group, i) => (
         <div className={styles.level} key={group}>
           <NumericInput
+            type="number"
             width={2}
             name={`weight-${group}`}
             value={weights[group] || ""}
@@ -137,6 +138,7 @@ export function WeightsControls({ usesTiers, high, low }: Props) {
         onChange={toggleGroupCheck}
       />
       <NumericInput
+        type="number"
         width={2}
         disabled={!groupSongsAt}
         value={groupSongsAt || high - 1}

--- a/src/controls/controls-weights.tsx
+++ b/src/controls/controls-weights.tsx
@@ -112,6 +112,7 @@ export function WeightsControls({ usesTiers, high, low }: Props) {
         <div className={styles.level} key={group}>
           <NumericInput
             type="number"
+            inputMode="numeric"
             width={2}
             name={`weight-${group}`}
             value={weights[group] || ""}
@@ -139,6 +140,7 @@ export function WeightsControls({ usesTiers, high, low }: Props) {
       />
       <NumericInput
         type="number"
+        inputMode="numeric"
         width={2}
         disabled={!groupSongsAt}
         value={groupSongsAt || high - 1}

--- a/src/controls/controls.css
+++ b/src/controls/controls.css
@@ -28,3 +28,13 @@
 .narrowInput {
   width: 100px;
 }
+
+/* remove native styling on number type inputs */
+input[type="number"] {
+  appearance: textfield;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  appearance: none;
+}

--- a/src/controls/index.tsx
+++ b/src/controls/index.tsx
@@ -319,6 +319,7 @@ function GeneralSettings() {
             large
             fill
             type="number"
+            inputMode="numeric"
             value={chartCount}
             min={1}
             clampValueOnBlur
@@ -344,6 +345,7 @@ function GeneralSettings() {
               large
               fill
               type="number"
+              inputMode="numeric"
               value={lowerBound}
               min={1}
               max={Math.max(upperBound, lowerBound, 1)}
@@ -363,6 +365,7 @@ function GeneralSettings() {
               large
               fill
               type="number"
+              inputMode="numeric"
               value={upperBound}
               min={lowerBound}
               max={lvlMax}

--- a/src/controls/index.tsx
+++ b/src/controls/index.tsx
@@ -318,6 +318,7 @@ function GeneralSettings() {
           <NumericInput
             large
             fill
+            type="number"
             value={chartCount}
             min={1}
             clampValueOnBlur
@@ -340,12 +341,13 @@ function GeneralSettings() {
             contentClassName={styles.narrowInput}
           >
             <NumericInput
+              large
               fill
+              type="number"
               value={lowerBound}
               min={1}
               max={Math.max(upperBound, lowerBound, 1)}
               clampValueOnBlur
-              large
               onValueChange={handleLowerBoundChange}
             />
           </FormGroup>
@@ -358,12 +360,13 @@ function GeneralSettings() {
             contentClassName={styles.narrowInput}
           >
             <NumericInput
+              large
               fill
+              type="number"
               value={upperBound}
               min={lowerBound}
               max={lvlMax}
               clampValueOnBlur
-              large
               onValueChange={handleUpperBoundChange}
             />
           </FormGroup>

--- a/src/controls/player-names.tsx
+++ b/src/controls/player-names.tsx
@@ -73,6 +73,7 @@ function PlayersPerDraw() {
   return (
     <FormGroup label={t("controls.playersPerDraw")}>
       <NumericInput
+        type="number"
         value={ppd}
         large
         min={0}

--- a/src/controls/player-names.tsx
+++ b/src/controls/player-names.tsx
@@ -74,6 +74,7 @@ function PlayersPerDraw() {
     <FormGroup label={t("controls.playersPerDraw")}>
       <NumericInput
         type="number"
+        inputMode="numeric"
         value={ppd}
         large
         min={0}


### PR DESCRIPTION
As suggested by rana in discord. The older, un-styled version of the app used to use these number types, but it was lost in the conversion to the new design system.