### PR TITLE
Fix sdvx accented titles and artists

### DIFF
--- a/scripts/import-sdvx.mjs
+++ b/scripts/import-sdvx.mjs
@@ -204,6 +204,39 @@ function reformatDate(input) {
 function buildSong(song, availableJackets) {
   const numericId = Number.parseInt(song.$.id, 10);
   const info = song.info[0];
+  // Fix accent issues with title/artist
+  let accent_lut = {
+    驩: "Ø",
+    齲: "♥",
+    齶: "♡",
+    趁: "Ǣ",
+    騫: "á",
+    曦: "à",
+    驫: "ā",
+    齷: "é",
+    曩: "è",
+    罇: "ê",
+    骭: "ü",
+    隍: "Ü",
+    雋: "Ǜ",
+    鬻: "♃",
+    鬥: "Ã",
+    鬆: "Ý",
+    鬮: "¡",
+    龕: "€",
+    蹙: "ℱ",
+    頽: "ä",
+    彜: "ū",
+    餮: "Ƶ",
+    墸: "\u035f\u035f\u035e\u0020",
+  };
+
+  let name = info.title_name[0];
+  let artist = info.artist_name[0];
+  for (const [orig, rep] of Object.entries(accent_lut)) {
+    name = name.replaceAll(orig, rep);
+    artist = artist.replaceAll(orig, rep);
+  }
 
   const bpmMax = info.bpm_max[0]._.slice(0, -2);
   const bpmMin = info.bpm_min[0]._.slice(0, -2);
@@ -249,11 +282,11 @@ function buildSong(song, availableJackets) {
 
   /** @type {Song} */
   const ret = {
-    name: info.title_name[0],
+    name: name,
     search_hint: info.ascii[0],
     date_added: reformatDate(info.distribution_date[0]._),
     saHash: song.$.id,
-    artist: info.artist_name[0],
+    artist: artist,
     jacket: usesSharedJacket
       ? `sdvx/jk_${("000" + parseInt(song.$.id)).slice(-4)}_1_s.png`
       : "sdvx6.png",

--- a/src/songs/sdvx.json
+++ b/src/songs/sdvx.json
@@ -14,7 +14,7 @@
       { "key": "exceed", "color": "#0047AB" }
     ],
     "flags": ["omegaDimension", "hexadiver", "otherEvents", "jpOnly"],
-    "lastUpdated": 1714024548898
+    "lastUpdated": 1714086068560
   },
   "defaults": {
     "style": "single",
@@ -355,7 +355,7 @@
       ]
     },
     {
-      "name": "Love齶sicK",
+      "name": "Love♡sicK",
       "search_hint": "lovesick_8prince",
       "date_added": "2012-01-18",
       "saHash": "9",
@@ -477,7 +477,7 @@
       ]
     },
     {
-      "name": "Love齶Shine わんだふるmix",
+      "name": "Love♡Shine わんだふるmix",
       "search_hint": "loveshine_arm",
       "date_added": "2012-01-18",
       "saHash": "13",
@@ -3163,7 +3163,7 @@
       ]
     },
     {
-      "name": "齷clair au chocolat",
+      "name": "éclair au chocolat",
       "search_hint": "eclair_au_chocolat_kamome",
       "date_added": "2012-11-22",
       "saHash": "121",
@@ -5258,7 +5258,7 @@
       ]
     },
     {
-      "name": "ませまてぃっく齲ま+ま=まじっく！",
+      "name": "ませまてぃっく♥ま+ま=まじっく！",
       "search_hint": "mathematic_kameria",
       "date_added": "2013-07-03",
       "saHash": "253",
@@ -7119,7 +7119,7 @@
       ]
     },
     {
-      "name": "choux 曦 la cr曩me",
+      "name": "choux à la crème",
       "search_hint": "choux_a_la_creme_kamome",
       "date_added": "2013-12-13",
       "saHash": "359",
@@ -10653,7 +10653,7 @@
       ]
     },
     {
-      "name": "Appliqu齷",
+      "name": "Appliqué",
       "search_hint": "applique_morimoriatsushi",
       "date_added": "2014-08-14",
       "saHash": "548",
@@ -11807,7 +11807,7 @@
       ]
     },
     {
-      "name": "じゅーじゅー齲焼肉の火からフェニックス！？～再誕の†炭火焼き～",
+      "name": "じゅーじゅー♥焼肉の火からフェニックス！？～再誕の†炭火焼き～",
       "search_hint": "juujuu_yakiniku_kameria",
       "date_added": "2015-11-13",
       "saHash": "611",
@@ -11836,7 +11836,7 @@
       ]
     },
     {
-      "name": "Le Fruit D齷fendu",
+      "name": "Le Fruit Défendu",
       "search_hint": "le_fruit_morimoriatsushi",
       "date_added": "2015-08-13",
       "saHash": "612",
@@ -12738,7 +12738,7 @@
       ]
     },
     {
-      "name": "混乱少女齲そふらんちゃん!!",
+      "name": "混乱少女♥そふらんちゃん!!",
       "search_hint": "konransyojo_kameria",
       "date_added": "2015-04-01",
       "saHash": "653",
@@ -12810,7 +12810,7 @@
       ]
     },
     {
-      "name": "cr罇pe suzette",
+      "name": "crêpe suzette",
       "search_hint": "crepe_suzette_kamome_sano",
       "date_added": "2015-10-22",
       "saHash": "656",
@@ -14927,7 +14927,7 @@
       ]
     },
     {
-      "name": "Chlo齷",
+      "name": "Chloé",
       "search_hint": "chloe_djtotoriott",
       "date_added": "2015-12-28",
       "saHash": "772",
@@ -15465,7 +15465,7 @@
       ]
     },
     {
-      "name": "UROB驩ROS",
+      "name": "UROBØROS",
       "search_hint": "uroboros_mizonokuchi",
       "date_added": "2016-06-16",
       "saHash": "798",
@@ -15527,7 +15527,7 @@
       "search_hint": "buchiage_doctor_mizonokuchi",
       "date_added": "2016-05-26",
       "saHash": "800",
-      "artist": "溝口ゆうま feat. みこ齶なち齶あい",
+      "artist": "溝口ゆうま feat. みこ♡なち♡あい",
       "jacket": "sdvx6.png",
       "bpm": "155",
       "charts": [
@@ -17630,7 +17630,7 @@
       "search_hint": "merriest_holic_uz",
       "date_added": "2016-07-28",
       "saHash": "904",
-      "artist": "miko齶nachi feat.u-z",
+      "artist": "miko♡nachi feat.u-z",
       "jacket": "sdvx/jk_0904_1_s.png",
       "bpm": "132",
       "charts": [
@@ -17892,7 +17892,7 @@
       ]
     },
     {
-      "name": "DIABLOSIS::N驫ga",
+      "name": "DIABLOSIS::Nāga",
       "search_hint": "diablosis_sky_delta",
       "date_added": "2016-08-10",
       "saHash": "914",
@@ -17927,7 +17927,7 @@
       ]
     },
     {
-      "name": "FL骭geL《Λrp:Σggy驩》",
+      "name": "FLügeL《Λrp:ΣggyØ》",
       "search_hint": "flugel_arpeggyo_kanekochiharu",
       "date_added": "2016-08-17",
       "saHash": "915",
@@ -18113,7 +18113,7 @@
       "search_hint": "nekokuma_mizonokuchi",
       "date_added": "2016-09-15",
       "saHash": "926",
-      "artist": "溝口ゆうま feat. みこ齶なち齶あい",
+      "artist": "溝口ゆうま feat. みこ♡なち♡あい",
       "jacket": "sdvx/jk_0926_1_s.png",
       "bpm": "180",
       "charts": [
@@ -18158,7 +18158,7 @@
       ]
     },
     {
-      "name": "PROVOES*PROPOSE <<罇l fine>>",
+      "name": "PROVOES*PROPOSE <<êl fine>>",
       "search_hint": "provoes_propose_yu_asahina",
       "date_added": "2018-09-13",
       "saHash": "929",
@@ -19443,7 +19443,7 @@
       ]
     },
     {
-      "name": "NEON LOVE齲POTION!!!",
+      "name": "NEON LOVE♥POTION!!!",
       "search_hint": "neon_love_potion_paitan",
       "date_added": "2017-09-14",
       "saHash": "994",
@@ -20178,7 +20178,7 @@
       ]
     },
     {
-      "name": "F騫fnir",
+      "name": "Fáfnir",
       "search_hint": "fafnir_aoi_sumito",
       "date_added": "2017-08-25",
       "saHash": "1029",
@@ -23009,7 +23009,7 @@
       "search_hint": "sacrifice_fsinfonia",
       "date_added": "2018-02-22",
       "saHash": "1180",
-      "artist": "蹙sinfonia（Yu_Asahina　溝口ゆうま　かなたん　大瀬良  あい）",
+      "artist": "ℱsinfonia（Yu_Asahina　溝口ゆうま　かなたん　大瀬良  あい）",
       "jacket": "sdvx/jk_1180_1_s.png",
       "bpm": "184-186",
       "charts": [
@@ -23212,7 +23212,7 @@
       "flags": ["omegaDimension"]
     },
     {
-      "name": "X齷roa",
+      "name": "Xéroa",
       "search_hint": "xeroa_kameria",
       "date_added": "2018-03-22",
       "saHash": "1189",
@@ -23344,7 +23344,7 @@
       ]
     },
     {
-      "name": "Levier'n N驫bYss",
+      "name": "Levier'n NābYss",
       "search_hint": "leviernnabyss_misoilepunch",
       "date_added": "2018-07-27",
       "saHash": "1195",
@@ -23510,7 +23510,7 @@
       ]
     },
     {
-      "name": "Яe's NoV趁",
+      "name": "Яe's NoVǢ",
       "search_hint": "resnovae_karatop",
       "date_added": "2018-03-22",
       "saHash": "1202",
@@ -23763,7 +23763,7 @@
       "search_hint": "buchiagesourou_mizonokuchi",
       "date_added": "2018-11-21",
       "saHash": "1213",
-      "artist": "溝口ゆうま feat. みこ齶なち齶あい",
+      "artist": "溝口ゆうま feat. みこ♡なち♡あい",
       "jacket": "sdvx/jk_1213_1_s.png",
       "bpm": "192",
       "charts": [
@@ -24149,7 +24149,7 @@
       ]
     },
     {
-      "name": "Li齷vre -blanche-",
+      "name": "Liévre -blanche-",
       "search_hint": "lievreblanche_diartzh",
       "date_added": "2018-08-16",
       "saHash": "1235",
@@ -24498,7 +24498,7 @@
       "search_hint": "houraifestival_mizonokuchi",
       "date_added": "2018-08-30",
       "saHash": "1252",
-      "artist": "溝口ゆうま feat. みこ齶なち齶あい",
+      "artist": "溝口ゆうま feat. みこ♡なち♡あい",
       "jacket": "sdvx/jk_1252_1_s.png",
       "bpm": "180",
       "charts": [
@@ -24780,11 +24780,11 @@
       "flags": ["omegaDimension"]
     },
     {
-      "name": "Xroni曩r",
+      "name": "Xronièr",
       "search_hint": "xronier_kameria",
       "date_added": "2018-08-09",
       "saHash": "1270",
-      "artist": "かめりあ as \"fluX Xrois齷\"",
+      "artist": "かめりあ as \"fluX Xroisé\"",
       "jacket": "sdvx/jk_1270_1_s.png",
       "bpm": "234",
       "charts": [
@@ -26163,7 +26163,7 @@
       "flags": ["omegaDimension"]
     },
     {
-      "name": "Σmbry驩",
+      "name": "ΣmbryØ",
       "search_hint": "embryo_kabocha",
       "date_added": "2019-02-07",
       "saHash": "1362",
@@ -26505,7 +26505,7 @@
       ]
     },
     {
-      "name": "J雋PITΨR 鬻 GЯ鬥VIT鬆",
+      "name": "JǛPITΨR ♃ GЯÃVITÝ",
       "search_hint": "jupitergravity_mizonokuchi",
       "date_added": "2019-06-13",
       "saHash": "1377",
@@ -27160,7 +27160,7 @@
       ]
     },
     {
-      "name": "Enchant齷",
+      "name": "Enchanté",
       "search_hint": "enchante_winddrums",
       "date_added": "2019-04-11",
       "saHash": "1410",
@@ -27835,7 +27835,7 @@
       ]
     },
     {
-      "name": "太陽曰く燃えよカオス（Sol oscuro 鬮Nya! Mix）",
+      "name": "太陽曰く燃えよカオス（Sol oscuro ¡Nya! Mix）",
       "search_hint": "taiyouiwaku_u1",
       "date_added": "2019-08-29",
       "saHash": "1446",
@@ -28015,7 +28015,7 @@
       ]
     },
     {
-      "name": "Daydream caf齷 (Euro Hopping Mix)",
+      "name": "Daydream café (Euro Hopping Mix)",
       "search_hint": "daydreamcafe_tag",
       "date_added": "2020-07-02",
       "saHash": "1458",
@@ -28085,7 +28085,7 @@
       ]
     },
     {
-      "name": "Σg驩",
+      "name": "ΣgØ",
       "search_hint": "ego_kabocha",
       "date_added": "2019-08-08",
       "saHash": "1462",
@@ -28724,7 +28724,7 @@
       "flags": ["omegaDimension"]
     },
     {
-      "name": "隍bertreffen",
+      "name": "Übertreffen",
       "search_hint": "ubertreffen_taka",
       "date_added": "2019-11-14",
       "saHash": "1502",
@@ -29079,7 +29079,7 @@
       ]
     },
     {
-      "name": "onslaught -Retaliation of Baham彜t-",
+      "name": "onslaught -Retaliation of Bahamūt-",
       "search_hint": "onslaughtrmx_kameria",
       "date_added": "2021-02-17",
       "saHash": "1528",
@@ -29359,7 +29359,7 @@
       ]
     },
     {
-      "name": "Xroni曦l X齷ro",
+      "name": "Xroniàl Xéro",
       "search_hint": "xronialxero_kameria",
       "date_added": "2020-08-06",
       "saHash": "1548",
@@ -29649,7 +29649,7 @@
       ]
     },
     {
-      "name": "龕omet popcorn",
+      "name": "€omet popcorn",
       "search_hint": "cometpopcorn_pan",
       "date_added": "2021-04-28",
       "saHash": "1562",
@@ -30323,7 +30323,7 @@
       "flags": ["hexadiver"]
     },
     {
-      "name": "Яe:son D'罇tre",
+      "name": "Яe:son D'être",
       "search_hint": "resondetre_schoolcaste",
       "date_added": "2020-08-13",
       "saHash": "1594",
@@ -30523,7 +30523,7 @@
       "search_hint": "valkyrjaaldrlag_fsinfonia",
       "date_added": "2020-10-29",
       "saHash": "1603",
-      "artist": "蹙sinfonia (Yu_Asahina 溝口ゆうま かなたん 大瀬良あい)",
+      "artist": "ℱsinfonia (Yu_Asahina 溝口ゆうま かなたん 大瀬良あい)",
       "jacket": "sdvx/jk_1603_1_s.png",
       "bpm": "185",
       "charts": [
@@ -30794,7 +30794,7 @@
       ]
     },
     {
-      "name": "Bol齷rrot",
+      "name": "Bolérrot",
       "search_hint": "bolerrot_kanekochiharu",
       "date_added": "2020-06-04",
       "saHash": "1618",
@@ -30959,7 +30959,7 @@
       ]
     },
     {
-      "name": "逆さま齲シンデレラパレード",
+      "name": "逆さま♥シンデレラパレード",
       "search_hint": "sakasamacinderella_merrybad",
       "date_added": "2020-07-01",
       "saHash": "1629",
@@ -31393,7 +31393,7 @@
       "search_hint": "mayhem_roughcanvasquimar",
       "date_added": "2020-11-19",
       "saHash": "1660",
-      "artist": "RoughSketch x CANVAS feat. Quim頽r",
+      "artist": "RoughSketch x CANVAS feat. Quimär",
       "jacket": "sdvx/jk_1660_1_s.png",
       "bpm": "998",
       "charts": [
@@ -31966,7 +31966,7 @@
       ]
     },
     {
-      "name": "charm齶you",
+      "name": "charm♡you",
       "search_hint": "charmyou_uske",
       "date_added": "2021-08-26",
       "saHash": "1687",
@@ -32271,7 +32271,7 @@
       ]
     },
     {
-      "name": "G4ME 驩VEЯ",
+      "name": "G4ME ØVEЯ",
       "search_hint": "gameover_takenoko",
       "date_added": "2021-06-10",
       "saHash": "1704",
@@ -32501,7 +32501,7 @@
       ]
     },
     {
-      "name": "ラヴ齶チャンス!!",
+      "name": "ラヴ♡チャンス!!",
       "search_hint": "lovechance_ponchi",
       "date_added": "2021-02-24",
       "saHash": "1718",
@@ -32596,7 +32596,7 @@
       ]
     },
     {
-      "name": "Verst頽rkt Killer",
+      "name": "Verstärkt Killer",
       "search_hint": "verstarkt_malva",
       "date_added": "2021-02-24",
       "saHash": "1724",
@@ -32641,7 +32641,7 @@
       ]
     },
     {
-      "name": "恋愛齶悪戯！？まじかる☆ぱふゅ～む！！",
+      "name": "恋愛♡悪戯！？まじかる☆ぱふゅ～む！！",
       "search_hint": "lovelovetrick_sawawa",
       "date_added": "2021-03-11",
       "saHash": "1727",
@@ -33475,7 +33475,7 @@
       "search_hint": "allforone_canvas",
       "date_added": "2022-02-15",
       "saHash": "1774",
-      "artist": "CANVAS feat. Quim頽r",
+      "artist": "CANVAS feat. Quimär",
       "jacket": "sdvx/jk_1774_1_s.png",
       "bpm": "185",
       "charts": [
@@ -33972,7 +33972,7 @@
       ]
     },
     {
-      "name": "驩餮",
+      "name": "ØƵ",
       "search_hint": "oz_hommarju",
       "date_added": "2022-10-06",
       "saHash": "1800",
@@ -35552,7 +35552,7 @@
       "search_hint": "grandeur_roughcanvasquimar",
       "date_added": "2022-07-14",
       "saHash": "1896",
-      "artist": "CANVAS x RoughSketch feat. Quim頽r",
+      "artist": "CANVAS x RoughSketch feat. Quimär",
       "jacket": "sdvx/jk_1896_1_s.png",
       "bpm": "190",
       "charts": [
@@ -36627,7 +36627,7 @@
       "flags": ["omegaDimension"]
     },
     {
-      "name": "Chat perch齷",
+      "name": "Chat perché",
       "search_hint": "chatperche_angeartnota",
       "date_added": "2022-12-08",
       "saHash": "1952",
@@ -37204,7 +37204,7 @@
       ]
     },
     {
-      "name": "ませまてぃっく齶ま＋ま＝まじっく！　～徹夜の追込みエナジーまっくす！～",
+      "name": "ませまてぃっく♡ま＋ま＝まじっく！　～徹夜の追込みエナジーまっくす！～",
       "search_hint": "masematicrmx_kah",
       "date_added": "2023-08-31",
       "saHash": "2006",
@@ -37511,7 +37511,7 @@
       ]
     },
     {
-      "name": "AP驩CALYPSE RAY",
+      "name": "APØCALYPSE RAY",
       "search_hint": "apocalypseray_xi",
       "date_added": "2023-08-09",
       "saHash": "2037",
@@ -38538,7 +38538,7 @@
       "flags": ["omegaDimension"]
     },
     {
-      "name": "TOYBOX CANN驩N=墸Σ≡=｡ﾟ:*.:+｡.☆",
+      "name": "TOYBOX CANNØN=͟͟͞ Σ≡=｡ﾟ:*.:+｡.☆",
       "search_hint": "toyboxcannon_mono",
       "date_added": "2024-02-15",
       "saHash": "2136",
@@ -38776,7 +38776,7 @@
       "flags": ["omegaDimension"]
     },
     {
-      "name": "MΔX FLAV驩R",
+      "name": "MΔX FLAVØR",
       "search_hint": "maxflavor_emocosine",
       "date_added": "2024-03-14",
       "saHash": "2149",


### PR DESCRIPTION
Uses a lookup table to convert the placeholder chinese characters into the intended characters that happen to not exist in shift_jis. The lookup table is not necessarily complete but I can't be bothered to check more than I already have