### PR TITLE
'Redraw' implementation of force expected distribution functionality

### DIFF
--- a/src/card-draw.ts
+++ b/src/card-draw.ts
@@ -267,7 +267,7 @@ export function draw(gameData: GameData, configData: ConfigState): Drawing {
    */
   const maxDrawPerBucket = new Map<number, number>();
   /**
-   * List of bucket indexes that must be picked first, to meet minimums. Only used with `forceDistribution`
+   * List of bucket indexes that must be picked, to meet minimums. Only used with `forceDistribution`
    */
   const requiredDrawIndexes: number[] = [];
 
@@ -280,7 +280,7 @@ export function draw(gameData: GameData, configData: ConfigState): Drawing {
       times(weightAmount, () => bucketDistribution.push(bucketIndex));
     }
 
-    // If we are focing distribution, maxDrawPerBucket[level] will be the maximum number
+    // If we are forcing distribution, maxDrawPerBucket[level] will be the maximum number
     // of cards of that level allowed in the card draw.
     // e.g. For a 5-card draw, we increase the cap by 1 at every 100%/5 = 20% threshold,
     // so a level with a weight of 15% can only show up on at most 1 card, a level with
@@ -307,62 +307,82 @@ export function draw(gameData: GameData, configData: ConfigState): Drawing {
     }
   }
 
-  const drawnCharts: DrawnChart[] = [];
-  /**
-   * Record of how many songs of each bucket index have been drawn so far
-   */
-  const difficultyCounts = new CountingSet<number>();
 
   // OK, setup work is done, here's whre we actually draw the cards!
-  while (drawnCharts.length < numChartsToRandom) {
-    if (bucketDistribution.length === 0) {
-      // no more songs available to pick in the requested range
-      // will be returning fewer than requested number of charts
-      break;
-    }
 
-    // first pick a difficulty (with priority to minimum draws)
-    let chosenBucketIdx = requiredDrawIndexes.shift();
-    if (chosenBucketIdx === undefined) {
+  let redraw = false;
+  const drawnCharts: DrawnChart[] = [];
+
+  do {
+
+    /**
+     * Record of how many songs of each bucket index have been drawn so far
+     */
+    const difficultyCounts = new CountingSet<number>();
+
+    while (drawnCharts.length < numChartsToRandom) {
+      if (bucketDistribution.length === 0) {
+        // no more songs available to pick in the requested range
+        // will be returning fewer than requested number of charts
+        break;
+      }
+
+      let chosenBucketIdx = undefined;
       [, chosenBucketIdx] = pickRandomItem(bucketDistribution);
-    }
-    if (chosenBucketIdx === undefined) {
-      // nothing left to draw
-      break;
-    }
-    const selectableCharts = validCharts.get(chosenBucketIdx);
-    if (!selectableCharts) {
-      // something bad happened?!
-      break;
-    }
-    const [randomIndex, randomChart] = pickRandomItem(selectableCharts);
 
-    if (randomChart) {
-      // Save it in our list of drawn charts
-      drawnCharts.push({
-        ...randomChart,
-        // Give this random chart a unique id within this drawing
-        id: `drawn_chart-${nanoid(5)}`,
-        type: CHART_DRAWN,
-      });
-      // remove drawn chart from deck so it cannot be re-drawn
-      selectableCharts.splice(randomIndex, 1);
-      difficultyCounts.add(chosenBucketIdx);
+      if (chosenBucketIdx === undefined) {
+        // nothing left to draw
+        break;
+      }
+      const selectableCharts = validCharts.get(chosenBucketIdx);
+      if (!selectableCharts) {
+        // something bad happened?!
+        break;
+      }
+      const [randomIndex, randomChart] = pickRandomItem(selectableCharts);
+
+      if (randomChart) {
+        // Save it in our list of drawn charts
+        drawnCharts.push({
+          ...randomChart,
+          // Give this random chart a unique id within this drawing
+          id: `drawn_chart-${nanoid(5)}`,
+          type: CHART_DRAWN,
+        });
+        // remove drawn chart from deck so it cannot be re-drawn
+        selectableCharts.splice(randomIndex, 1);
+        difficultyCounts.add(chosenBucketIdx);
+      }
     }
 
-    // check if maximum number of expected occurrences of this level of chart has been reached
-    const reachedExpected =
-      forceDistribution &&
-      difficultyCounts.get(chosenBucketIdx) ===
-        maxDrawPerBucket.get(chosenBucketIdx);
+    if (useWeights && forceDistribution) {
+      // Check if we have a valid draw, if not discard and redraw
 
-    if (selectableCharts.length === 0 || reachedExpected) {
-      // can't pick any more songs of this difficulty
-      bucketDistribution = bucketDistribution.filter(
-        (n) => n !== chosenBucketIdx,
-      );
+      for (const bucketIndex of validCharts.keys()) {
+        let numRequiredCount = 0;
+
+        let numMaximumAllowed = maxDrawPerBucket.get(bucketIndex) || 0;
+
+        for (let i=0; i <= requiredDrawIndexes.length; i++) {
+          if (requiredDrawIndexes[i] == bucketIndex){
+            numRequiredCount++;
+          }
+        }
+
+        let numDrawn = difficultyCounts.get(bucketIndex)
+        const underDrawn = numDrawn < numRequiredCount;
+        const overDrawn = numDrawn > numMaximumAllowed;
+
+        redraw = false;
+        if (underDrawn || overDrawn) {
+          redraw = true
+          drawnCharts.splice(0,drawnCharts.length)
+          break;
+        }
+      }
     }
-  }
+
+  } while (redraw);
 
   const charts: Drawing["charts"] = configData.sortByLevel
     ? drawnCharts.sort(

--- a/src/card-draw.ts
+++ b/src/card-draw.ts
@@ -307,14 +307,12 @@ export function draw(gameData: GameData, configData: ConfigState): Drawing {
     }
   }
 
-
   // OK, setup work is done, here's whre we actually draw the cards!
 
   let redraw = false;
   const drawnCharts: DrawnChart[] = [];
 
   do {
-
     /**
      * Record of how many songs of each bucket index have been drawn so far
      */
@@ -363,25 +361,24 @@ export function draw(gameData: GameData, configData: ConfigState): Drawing {
 
         let numMaximumAllowed = maxDrawPerBucket.get(bucketIndex) || 0;
 
-        for (let i=0; i <= requiredDrawIndexes.length; i++) {
-          if (requiredDrawIndexes[i] == bucketIndex){
+        for (let i = 0; i <= requiredDrawIndexes.length; i++) {
+          if (requiredDrawIndexes[i] == bucketIndex) {
             numRequiredCount++;
           }
         }
 
-        let numDrawn = difficultyCounts.get(bucketIndex)
+        let numDrawn = difficultyCounts.get(bucketIndex);
         const underDrawn = numDrawn < numRequiredCount;
         const overDrawn = numDrawn > numMaximumAllowed;
 
         redraw = false;
         if (underDrawn || overDrawn) {
-          redraw = true
-          drawnCharts.splice(0,drawnCharts.length)
+          redraw = true;
+          drawnCharts.splice(0, drawnCharts.length);
           break;
         }
       }
     }
-
   } while (redraw);
 
   const charts: Drawing["charts"] = configData.sortByLevel


### PR DESCRIPTION
As currently implemented, the 'Force Expected Distribution' checkbox does not work as intended across multiple draws when one or more of the difficulty buckets are not required to be in the draw.  

For example, Assume the following distribution is set for DDR difficulties 15-18:

15: 10%
16: 30%
17: 30%
18: 30%

One would expected that over the course of 100 5-card draws (500 cards total), that 50 of the cards would from the 15 difficulty would be drawn. However, the current implementation would only produce around 10-15 of these on average, severely under-representing the difficulty across multiple draws. In the code, I believe this is because it draws all required cards first, and then any remaining cards are drawn with the set weights. However, this results in the 15 having only a 10% chance to be drawn on the remaining two cards left instead of all five cards, resulting in much lower odds of it being drawn overall.

My fix is a bit of a brute force approach where it performs the weighted distribution draws as normal, but simply checks if all the minimum and maximum criteria are met for the draw. If the criteria aren't met, it throws away the draw and tries again. This way at least every card drawn is respecting the weights that the user set, and it should lead to a much closer expected outcome over the course of multiple draws.

There's probably a better way that doesn't involve brute force, but this should be a quick fix at least.