### PR TITLE
Player Name Support on Mobile Devices

### DIFF
--- a/src/controls/player-names.tsx
+++ b/src/controls/player-names.tsx
@@ -49,6 +49,7 @@ export function PlayerNamesControls() {
           leftIcon={<Person size={20} className={Classes.TAG_INPUT_ICON} />}
           onAdd={addPlayers}
           onRemove={removePlayer}
+          addOnBlur={true}
         />
       </FormGroup>
       <TournamentLabelEditor />


### PR DESCRIPTION
Most mobile devices can't use player names, as player names wouldn't get added when the user moved to another field.

Adding the `addOnBlur` option allows mobile to be supported with no affect on desktop mode.

Bug State (notice the focus is on the 'x' of the `Pools | x` tag and that the player name is not added):
<img width="770" height="535" alt="image" src="https://github.com/user-attachments/assets/c461205c-9d02-4cc7-bbbe-a86520e1f285" />

Fix (the player is added):
<img width="746" height="519" alt="image" src="https://github.com/user-attachments/assets/e34bb2c9-d1c8-4625-b296-beb1de9aa015" />
 