### PR TITLE
Update smx.json to fix flags

### DIFF
--- a/src/songs/smx.json
+++ b/src/songs/smx.json
@@ -262,7 +262,6 @@
       "name": "Party People",
       "artist": "Oscillator X",
       "genre": "Dance",
-      "flags": ["cappRecords"],
       "bpm": "125",
       "jacket": "smx/PartyPeople.jpg",
       "charts": [
@@ -2239,7 +2238,8 @@
         { "style": "solo", "lvl": 15, "diffClass": "hard" },
         { "style": "solo", "lvl": 20, "diffClass": "wild" },
         { "style": "solo", "lvl": 17, "diffClass": "dual" },
-        { "style": "solo", "lvl": 20, "diffClass": "full" }
+        { "style": "solo", "lvl": 20, "diffClass": "full" },
+        { "style": "team", "lvl": 22, "diffClass": "team" }
       ],
       "saIndex": "318"
     },


### PR DESCRIPTION
Oscillator X "Party People" caught some strays from the DLC "Party People", resulting in it never being drawn when DLC was disabled.

Bad 4 My Health also had its Team chart added.