### PR TITLE
Added basic Dockerfile for containerized deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:22-bookworm AS builder
+WORKDIR /app
+COPY . /app/
+RUN yarn install && yarn build
+
+FROM nginx:1.31.0-alpine
+WORKDIR /usr/share/nginx/html
+COPY --from=builder /app/dist /usr/share/nginx/html/

--- a/README.md
+++ b/README.md
@@ -53,3 +53,20 @@ yarn import:itg path/to/pack/folder some-stub-name
 # https://github.com/AnyhowStep/pump-out-sqlite3-dump/
 yarn import:pump path/to/pumpout/db
 ```
+
+## Deployment
+
+As mentioned above, running `yarn build` will create a distribution of the application with static content that can be used in a production environment in a multitude of ways. The following are options for deployment
+
+### Local
+
+Running `yarn build:zip` produces a zip file that can be extracted anywhere on your PC. Simply open the included `index.html` to start using DDRCardDraw. That's it!
+
+### Docker/Containers
+
+For more advanced users, a Dockerfile has been included to produce a docker image that can be deployed in any container environment, whether it is using the docker engine directly or using an orchestration tool like docker-compose or kubernetes.
+
+```sh
+docker build -t ddrcarddraw .
+docker run ddrcarddraw
+```


### PR DESCRIPTION
This PR is meant to simply provide a Dockerfile that can be used to create a docker image for the application. This can be used by people to rapidly create a production-ready deployment of the application. 

This does not include any changes to any workflows. The Docker deployment is an optional step developers can leverage.

If you would like to remove or change the notes added to the README, I will not be offended.