### PR TITLE
Fix bucket generation for games with inherent fractional difficulty levels

### DIFF
--- a/src/card-draw.ts
+++ b/src/card-draw.ts
@@ -1,6 +1,6 @@
 import { nanoid } from "nanoid";
 import { GameData, Song, Chart } from "./models/SongData";
-import { chunkInPieces, pickRandomItem, rangeI, shuffle, times } from "./utils";
+import { chunkInPieces, pickRandomItem, shuffle, times } from "./utils";
 import { CountingSet } from "./utils/counting-set";
 import { DefaultingMap } from "./utils/defaulting-set";
 import { Fraction } from "./utils/fraction";
@@ -169,12 +169,12 @@ export function* getBuckets(
     }
     return;
   }
-  // TODO: create an array of available levels within range here (slice of availableLvls)
+  const levelsInRange = availableLvls.filter(
+    (lvl) => lvl >= lowerBound && lvl <= upperBound,
+  );
 
   if (!granularResolution || !cfg.useGranularLevels) {
-    // TODO: reuse that here
-    const levels = Array.from(rangeI(lowerBound, upperBound));
-    for (const chunk of chunkInPieces(probabilityBucketCount, levels)) {
+    for (const chunk of chunkInPieces(probabilityBucketCount, levelsInRange)) {
       yield [chunk[0], chunk[chunk.length - 1]];
     }
     return;

--- a/src/controls/controls-weights.tsx
+++ b/src/controls/controls-weights.tsx
@@ -16,6 +16,12 @@ interface Props {
 }
 const pctFmt = new Intl.NumberFormat(undefined, { style: "percent" });
 
+/** number of digits after the decimal point in a number's string form */
+function decimalDigits(n: number) {
+  const decimalIndex = n.toString().indexOf(".");
+  return decimalIndex === -1 ? 0 : n.toString().length - decimalIndex - 1;
+}
+
 function printGroup(
   group: LevelRangeBucket | number,
   precisionRange: number | undefined,
@@ -23,7 +29,13 @@ function printGroup(
   if (typeof group === "number") {
     return group.toString();
   } else {
-    const digits = precisionRange && (1 / precisionRange).toString().length - 2;
+    // games with a configured granular tier resolution use that to determine
+    // display precision, but some games (eg SDVX) have inherently fractional
+    // levels with no granular toggle, so fall back to the precision actually
+    // present in the bucket bounds
+    const digits = precisionRange
+      ? (1 / precisionRange).toString().length - 2
+      : Math.max(decimalDigits(group[0]), decimalDigits(group[1]));
     if (group[0] === group[1]) {
       return group[0].toFixed(digits);
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -113,15 +113,6 @@ export function firstOf<T>(iter: IterableIterator<T>): T | undefined {
 }
 
 /**
- * Range, inclusive
- */
-export function* rangeI(start: number, end: number) {
-  for (let i = start; i <= end; i++) {
-    yield i;
-  }
-}
-
-/**
  * Split an array up into chunks of a regular size
  * @param chunkSize
  * @param arr


### PR DESCRIPTION
getBuckets() previously assumed integer-valued levels in the non-granular
weighted-draw path, building the level list via rangeI(lowerBound, upperBound).
For games like SDVX where chart.lvl itself is fractional (e.g. 18.2, 18.3) and
there is no granular-levels toggle, this collapsed any sub-1.0 range (e.g.
18-18.9) into a single integer bucket, and silently dropped the fractional
charts from weighted draws since they no longer matched any bucket range.

Derive the bucket source list from the actual availableLvls passed in
(filtered to the configured bounds) instead of assuming integer steps, which
naturally handles both integer-level and fractional-level games.