### PR TITLE
Fix removing protect/pocket action also clearing marked winner

### DIFF
--- a/src/drawing-context.tsx
+++ b/src/drawing-context.tsx
@@ -87,11 +87,14 @@ const {
       });
     },
     resetChart(chartId) {
+      // Note: winners are intentionally left untouched here. A chart can have
+      // both an action (protect/pocket/ban) and a marked winner at the same
+      // time, and removing the action should not clear the winner. Winners are
+      // removed via their own control (setWinner(chartId, null)).
       set((d) => ({
         bans: d.bans.filter((p) => p.chartId !== chartId),
         protects: d.protects.filter((p) => p.chartId !== chartId),
         pocketPicks: d.pocketPicks.filter((p) => p.chartId !== chartId),
-        winners: d.pocketPicks.filter((p) => p.chartId !== chartId),
       }));
     },
     redrawChart(chartId) {


### PR DESCRIPTION
## Problem

A drawn card can have both an action label (protect / pocket pick / ban) **and** a marked winner at the same time — the song-card menu allows setting a winner on a card that already carries a label.

Each action label's "X" remove button calls `onReset` → `resetChart`. That function cleared the chart's entry from **all** lists, including `winners`. So removing a protect (or pocket pick) on a card that also had a winner marked would wipe the winner as well.

The bug was compounded by a copy-paste error in `resetChart`:

```js
winners: d.pocketPicks.filter((p) => p.chartId !== chartId),
```

It filtered `pocketPicks` (wrong list and wrong type) and assigned the result to `winners`.

## Fix

The winner label has its own independent removal control (`setWinner(chartId, null)`), so `resetChart` never needs to touch the winners list. Removed the line and documented the intent.

Now removing a protect/pocket/ban leaves any marked winner intact, while the winner can still be cleared on its own.

## Note

The same issue exists on the `partykit` branch (`src/state/drawings.slice.ts` — `resetChart` deletes `drawing.winners[chartId]`). That branch isn't touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLriWZavKpUVqb9VRoB6vL)_