### PR TITLE
Fix removing protect/pocket action also clearing marked winner (partykit)

### DIFF
--- a/src/state/drawings.slice.ts
+++ b/src/state/drawings.slice.ts
@@ -122,10 +122,13 @@ export const drawingsSlice = createSlice({
       if (!drawing) {
         return;
       }
+      // Note: the winner is intentionally left untouched here. A chart can
+      // have both an action (protect/pocket/ban) and a marked winner at the
+      // same time, and removing the action should not clear the winner. The
+      // winner is removed via its own control (setWinner with player: null).
       delete drawing.bans[chartId];
       delete drawing.protects[chartId];
       delete drawing.pocketPicks[chartId];
-      delete drawing.winners[chartId];
     },
     banProtectReplace(
       state,


### PR DESCRIPTION
## Problem

This is the `partykit`-branch equivalent of the fix merged to `main`.

A drawn card can have both an action label (protect / pocket pick / ban) **and** a marked winner at the same time. Each action label's "X" remove button calls `onReset`, which dispatches the `resetChart` reducer in `src/state/drawings.slice.ts`. That reducer deleted the chart's entry from **all** maps, including `winners`:

```js
delete drawing.bans[chartId];
delete drawing.protects[chartId];
delete drawing.pocketPicks[chartId];
delete drawing.winners[chartId];   // ← wiped the winner too
```

So removing a protect (or pocket pick) on a card that also had a winner marked would clear the winner as well.

## Fix

The winner has its own independent removal control (`setWinner` with `player: null`), so `resetChart` never needs to touch the winner. Dropped the `delete drawing.winners[chartId];` line and documented the intent.

Now removing a protect/pocket/ban leaves any marked winner intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLriWZavKpUVqb9VRoB6vL)_