### PR TITLE
Implement incremental catch-up and heartbeat for sync resilience

### DIFF
--- a/docs/partykit-sync-design.md
+++ b/docs/partykit-sync-design.md
@@ -65,9 +65,15 @@ All messages are JSON. The types live in `src/party/types.ts`.
 | `{type:"action", action, id, seq}`                | server → **all** clients | The same action, stamped with its canonical position. The copy sent back to the sender doubles as the receipt confirmation.                                                          |
 | `{type:"roomstate", state, seq, recentActionIds}` | server → one client      | Full state snapshot, sent on every (re)connect. `seq` is the last action baked into `state`; `recentActionIds` lets a reconnecting client drop pending re-sends that already landed. |
 | `{type:"ack", id}`                                | server → sender          | Sent instead of a re-apply when a duplicate re-send arrives for an already-applied `id`.                                                                                             |
+| `{type:"catchup", since}`                         | client → server          | "I saw a gap on a live socket; replay every stamped action after `since`." Sent instead of tearing down the socket for a fresh snapshot.                                             |
+| `{type:"catchup", actions}`                       | server → sender          | The stamped actions with `seq > since`, ascending. If the gap reaches back further than the server's retained tail, the server sends a `roomstate` instead and the client resyncs.   |
+| `{type:"ping"}` / `{type:"pong"}`                 | client ⇄ server          | Application-level heartbeat. The client pings every ~10s; two unanswered pings mean a stalled (half-open) socket and force a reconnect.                                              |
 
 `id` and `seq` are optional on the wire for compatibility with older
-deployments; see "Version interop" at the end.
+deployments; see "Version interop" at the end. The `catchup`, `ping`, and
+`pong` messages are additive: an older server never answers `catchup` (the
+catch-up timeout falls back to a reconnect) and never sends `pong` (the
+missed-pong counter forces a harmless reconnect that lands a fresh roomstate).
 
 ## The client state model
 
@@ -240,10 +246,55 @@ Two details worth knowing:
   action that actually landed just before the disconnect isn't applied a
   second time.
 
-If a client ever observes a **gap in `seq`** (a missed broadcast on a live
-socket), it can't trust its confirmed state anymore; the repair is to force
-a reconnect and take a fresh roomstate (`resync` handler wired to
-`socket.reconnect()` in `src/party/client.tsx`).
+### Incremental catch-up: repairing a gap without a reconnect
+
+If a client observes a **gap in `seq`** (a missed broadcast on a live
+socket) it can't trust its confirmed state anymore, but the socket itself is
+fine — only a frame or two went missing. Rather than tear the connection down
+for a full snapshot, the client asks the server to replay just the actions it
+missed:
+
+```mermaid
+sequenceDiagram
+    participant M as SyncManager
+    participant S as Server
+
+    Note over M: lastSeq = 40, receives seq:43 → gap
+    Note over M: resyncing = true; buffer live broadcasts (43, 44, ...)
+    M->>S: {type:"catchup", since:40}
+    Note over S: tail still holds 41, 42, 43, ...
+    S->>M: {type:"catchup", actions:[41, 42, 43, ...]}
+    Note over M: apply in order → confirmed advances to head of tail<br/>drain buffered 44, ... → resyncing = false
+```
+
+- The server keeps an in-memory **tail** of the last `MAX_TAIL` (500) stamped
+  actions (`src/party/server.ts`). `handleCatchup` returns every tail entry
+  with `seq > since`. This is safe to keep in memory only: a client can only
+  see a live-socket gap while _this same actor_ has been running continuously,
+  so the tail is intact. A restart or hibernation drops every socket, so
+  clients reconnect and take a fresh roomstate instead of ever catching up.
+- If the gap reaches back **further than the tail** (`since` older than the
+  oldest retained action), the server sends a `roomstate` instead and the
+  client resyncs wholesale — the same code path as a reconnect.
+- While a catch-up is in flight the client sets `resyncing` and **buffers**
+  every live broadcast (`SyncManager.buffer`); once the replayed actions fill
+  the gap it drains the buffer in `seq` order (`drainBuffer`). A gap that
+  reopens mid-drain simply starts another catch-up round.
+- Catch-up requests re-send on a 5s timeout and, after
+  `MAX_CATCHUP_ATTEMPTS` (3) unanswered rounds, fall back to
+  `socket.reconnect()` (the `resync` handler) — so a server that doesn't
+  understand `catchup` still recovers.
+
+### Heartbeat: noticing a stalled-but-open socket
+
+A websocket can stay `OPEN` while the server is frozen or the TCP link is
+half-open; nothing surfaces the dead connection until a send's ack times out.
+An application-level heartbeat closes that window: `PartySocketManager` pings
+every `HEARTBEAT_INTERVAL_MS` (~10s) and, after `MAX_MISSED_PONGS` (2)
+unanswered pings, calls `socket.reconnect()` to force the normal
+disconnect/reconnect flow. The pong counter resets whenever a `pong` or a
+fresh roomstate arrives. This is the failure mode exercised by SIGSTOP-ing
+`workerd` in `.claude/skills/verify/SKILL.md`.
 
 ## User-facing connection health
 
@@ -269,8 +320,13 @@ chrome.
 1. **In-memory redux store** — authoritative while the room actor is alive.
    Hydrated in `onStart` from room storage, falling back to Supabase, with
    `applyMigrations` (`src/state/migrations.ts`) run over whatever loads.
-2. **PartyKit room storage** — `currentState` key, rewritten after every
-   applied action. Survives room hibernation/restarts.
+2. **PartyKit room storage** — the `currentState` key, rewritten after every
+   applied action, plus a `syncMeta` key (`{seq, seenIds}`) written alongside
+   it. `syncMeta` lets a hibernated or restarted room resume the sequencer
+   where it left off instead of resetting `seq` to 0, and keeps the dedupe set
+   warm so a client's re-send that spans the hibernation isn't applied a second
+   time. Both survive room hibernation/restarts. (The catch-up `tail` is
+   deliberately _not_ persisted — see "Incremental catch-up" above.)
 3. **Supabase** (`event_state` table, typed in
    `src/party/database.types.ts`) — best-effort upsert after every action;
    disabled unless `SUPABASE_URL`/`SUPABASE_KEY` are present. Serves as
@@ -292,8 +348,13 @@ corrupting state:
   recognize their own echo and would double-apply it.
 - A roomstate **without `seq`** (older server) drops the client back to
   plain optimistic apply: pending tracking still works via `ack`s, but no
-  rebasing and no give-up rollback (guarded by `lastSeq == null` in
-  `src/party/sync-manager.ts`).
+  rebasing, no give-up rollback, and no catch-up (all guarded by
+  `lastSeq == null` in `src/party/sync-manager.ts`).
+- `catchup`, `ping`, and `pong` are additive messages an older server ignores.
+  A new client against such a server never gets a `catchup` reply (the 5s
+  catch-up timeout falls back to `socket.reconnect()`) and never gets a `pong`
+  (the missed-pong counter forces a reconnect on the same path). Both degrade
+  to the pre-step-2 behavior of reconnecting for a fresh roomstate.
 - Deploy order when the protocol grows: **server first, web app second.**
 
 ## Poking at it locally
@@ -302,5 +363,5 @@ Run `yarn start:backend` (PartyKit on `:1999`) and `yarn start:frontend`
 (webpack on `:8080`), then open `/e/any-room-name` in two tabs and watch the
 websocket frames in devtools. `.claude/skills/verify/SKILL.md` documents a
 scripted version of this, including how to freeze the server mid-flight
-(SIGSTOP the `workerd` process) to exercise the retry, rebase, and
-reconnect paths.
+(SIGSTOP the `workerd` process) to exercise the retry, rebase, catch-up,
+heartbeat, and reconnect paths.

--- a/docs/partykit-sync-design.md
+++ b/docs/partykit-sync-design.md
@@ -59,21 +59,48 @@ factory but never connects a socket.
 
 All messages are JSON. The types live in `src/party/types.ts`.
 
-| Message                                           | Direction                | Meaning                                                                                                                                                                              |
-| ------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `{type:"action", action, id}`                     | client → server          | "Please apply this redux action." `id` is a unique message id (nanoid) used for receipt confirmation and dedupe.                                                                     |
-| `{type:"action", action, id, seq}`                | server → **all** clients | The same action, stamped with its canonical position. The copy sent back to the sender doubles as the receipt confirmation.                                                          |
-| `{type:"roomstate", state, seq, recentActionIds}` | server → one client      | Full state snapshot, sent on every (re)connect. `seq` is the last action baked into `state`; `recentActionIds` lets a reconnecting client drop pending re-sends that already landed. |
-| `{type:"ack", id}`                                | server → sender          | Sent instead of a re-apply when a duplicate re-send arrives for an already-applied `id`.                                                                                             |
-| `{type:"catchup", since}`                         | client → server          | "I saw a gap on a live socket; replay every stamped action after `since`." Sent instead of tearing down the socket for a fresh snapshot.                                             |
-| `{type:"catchup", actions}`                       | server → sender          | The stamped actions with `seq > since`, ascending. If the gap reaches back further than the server's retained tail, the server sends a `roomstate` instead and the client resyncs.   |
-| `{type:"ping"}` / `{type:"pong"}`                 | client ⇄ server          | Application-level heartbeat. The client pings every ~10s; two unanswered pings mean a stalled (half-open) socket and force a reconnect.                                              |
+| Message                                           | Direction                | Meaning                                                                                                                                                                                                                      |
+| ------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{type:"action", action, id}`                     | client → server          | "Please apply this redux action." `id` is a unique message id (nanoid) used for receipt confirmation and dedupe.                                                                                                             |
+| `{type:"action", action, id, seq}`                | server → **all** clients | The same action, stamped with its canonical position. The copy sent back to the sender doubles as the receipt confirmation. Only ever sent for an action the server **already applied** — see "apply before ordering" below. |
+| `{type:"roomstate", state, seq, recentActionIds}` | server → one client      | Full state snapshot, sent on every (re)connect. `seq` is the last action baked into `state`; `recentActionIds` lets a reconnecting client drop pending re-sends that already landed.                                         |
+| `{type:"ack", id}`                                | server → sender          | Sent instead of a re-apply when a duplicate re-send arrives for an already-applied `id`.                                                                                                                                     |
+| `{type:"reject", id, reason}`                     | server → sender          | The reducer threw on this action, so it was never ordered, broadcast, or applied. The sender rolls it back out of its display state immediately instead of waiting out the ack timeout.                                      |
+| `{type:"catchup", since}`                         | client → server          | "I saw a gap on a live socket; replay every stamped action after `since`." Sent instead of tearing down the socket for a fresh snapshot.                                                                                     |
+| `{type:"catchup", actions}`                       | server → sender          | The stamped actions with `seq > since`, ascending. If the gap reaches back further than the server's retained tail, the server sends a `roomstate` instead and the client resyncs.                                           |
+| `{type:"ping"}` / `{type:"pong"}`                 | client ⇄ server          | Application-level heartbeat. The client pings every ~10s; two unanswered pings mean a stalled (half-open) socket and force a reconnect.                                                                                      |
 
 `id` and `seq` are optional on the wire for compatibility with older
 deployments; see "Version interop" at the end. The `catchup`, `ping`, and
 `pong` messages are additive: an older server never answers `catchup` (the
 catch-up timeout falls back to a reconnect) and never sends `pong` (the
 missed-pong counter forces a harmless reconnect that lands a fresh roomstate).
+`reject` is likewise additive: an older server simply never sends one, and a
+rejected action falls back to being abandoned by the ack timeout.
+
+### Apply before ordering
+
+The server dispatches an action into its own store **before** stamping it with
+a `seq` and broadcasting it. This ordering is load-bearing, because the echo
+doubles as the receipt confirmation: anything broadcast is a promise that the
+server applied it.
+
+Ordering first would break that promise whenever the reducer throws. The
+action would reach every peer, take a `seq` the server's own store never
+advanced past, and — since the tail was introduced — enter both the catch-up
+replay tail and `recentActionIds`. The server would be silently behind every
+client, with no divergence signal, until the next `roomstate` reverted
+everyone at once. A client would have no way to notice: its pending entry is
+settled by the echo, and `recentActionIds` would tell a reconnecting client
+the effect was already baked into the snapshot when it never was.
+
+So a throwing action consumes no `seq`, is not remembered, is not broadcast,
+and never enters the tail. The room is left exactly as it was, and the sender
+gets a `reject` so it can roll the optimistic change back out immediately
+rather than waiting out four ack timeouts.
+
+A legacy client (no `id`) has no ack channel, so its rejections are silent —
+the action is still refused, it just cannot be told.
 
 ## The client state model
 
@@ -307,6 +334,7 @@ All the toasts live in `src/party/client.tsx` (strings in
 | Edit attempted while blocked          | warning toast, action dropped by the gate |
 | Roomstate applied after reconnect     | success toast, edits re-enabled           |
 | Action abandoned after repeated sends | danger toast + local rollback             |
+| Action rejected by the server         | danger toast + local rollback             |
 
 Toasts render through the app-root `OverlayToaster` (`src/toaster.tsx`) and
 are suppressed when running inside an OBS browser source (`useInObs` from

--- a/docs/partykit-sync-roadmap.md
+++ b/docs/partykit-sync-roadmap.md
@@ -43,13 +43,17 @@ recentActionIds}`.
   - A foreign action arriving while pending actions exist triggers a rebase:
     recompute display = confirmed + pending, delivered via
     `receivePartyState` (wholesale state replacement in the root reducer).
-  - A `seq` gap means a missed broadcast; the only repair today is
-    `socket.reconnect()` → fresh roomstate (see step 2 for the cheaper fix).
+  - A `seq` gap means a missed broadcast; the repair is an incremental
+    catch-up (`{type:"catchup", since}` → the missing stamped actions),
+    falling back to `socket.reconnect()` → fresh roomstate only when the gap
+    predates the server's tail or catch-up goes unanswered (step 2).
   - On roomstate: pending ids listed in `recentActionIds` are dropped (their
     effects are baked into the snapshot); the rest are rebased and re-sent.
 - Connection health: dispatch is gated off (`partyGateMiddleware`) from
   socket-close until the post-reconnect roomstate is fully applied; users see
-  disconnect / blocked / reconnected toasts (suppressed in OBS sources).
+  disconnect / blocked / reconnected toasts (suppressed in OBS sources). An
+  application-level heartbeat (`ping`/`pong`) forces a reconnect when a socket
+  stalls while still open (step 2).
 
 ### Hard requirement: deterministic reducers
 
@@ -80,22 +84,30 @@ fixed in PR #604. Audit any new reducer for this.
 Described above. Kills the divergence class caused by clients applying
 concurrent actions in different orders.
 
-### Step 2 — incremental catch-up + heartbeat (next)
+### Step 2 — incremental catch-up + heartbeat ✅
 
-- Server keeps a tail of recent stamped actions (say 500) in room storage.
-  Client sends `{type: "catchup", since: seq}` on a detected gap; server
-  replies with the missing stamped actions (or a full roomstate if the tail
-  doesn't reach back far enough). Replaces reconnect-as-only-repair; makes
-  brief drops nearly free.
-- Application-level heartbeat: client pings every ~10s, treats N missed pongs
-  as a dead connection and forces the reconnect flow. Today a
-  stalled-but-open socket (server frozen, half-open TCP) isn't noticed until
-  an ack timeout — verified with SIGSTOP on workerd, see
+- Server keeps an in-memory tail of the last 500 stamped actions. The client
+  sends `{type: "catchup", since: seq}` on a detected gap; the server replies
+  with the missing stamped actions (or a full roomstate if the tail doesn't
+  reach back far enough). Replaces reconnect-as-only-repair; makes brief drops
+  nearly free. The client buffers live broadcasts while a catch-up is in
+  flight and drains them once the gap closes.
+  - **The tail is memory-only, not in room storage** (the original plan said
+    storage). A client can only observe a live-socket gap while the same actor
+    has been running the whole time, so the in-memory tail is always intact for
+    the case catch-up serves; a restart/hibernation drops every socket and
+    clients take a fresh roomstate anyway. Persisting the full action bodies on
+    every write would be the write-amplification step 3 is trying to _remove_.
+- Application-level heartbeat: the client pings every ~10s and treats 2 missed
+  pongs as a dead connection, forcing the reconnect flow. A stalled-but-open
+  socket (server frozen, half-open TCP) is otherwise not noticed until an ack
+  timeout — verified with SIGSTOP on workerd, see
   `.claude/skills/verify/SKILL.md`.
-- Move `seq` and the dedupe id set into room storage so PartyKit hibernation
-  or a server restart can't reset them (today: in-memory; safe only because a
-  restart drops all sockets, forcing full roomstate resyncs; the dedupe
-  window across hibernation is a known small hole).
+- `seq` and the dedupe id set now persist to room storage (the `syncMeta` key,
+  written alongside `currentState`) so PartyKit hibernation or a server restart
+  can't reset `seq` to 0 or forget applied ids — closing the
+  dedupe-across-hibernation hole. (The tail, being memory-only, is not part of
+  this blob.)
 
 ### Step 3 — event-sourcing lite
 

--- a/docs/partykit-sync-roadmap.md
+++ b/docs/partykit-sync-roadmap.md
@@ -31,6 +31,11 @@ invariants. CRDTs are deliberately **not** on this path (see last section).
     monotonic `seq`. The echo doubles as the receipt confirmation (ack).
   - server → sender only: `{type: "ack", id, ...}` when a duplicate re-send
     arrives for an already-applied id.
+  - server → sender only: `{type: "reject", id, reason}` when the reducer
+    threw. The server applies an action _before_ stamping and broadcasting it,
+    so the echo only ever promises something that actually applied; a throwing
+    action consumes no seq, never enters the tail or `recentActionIds`, and is
+    rolled back on the sender instead of silently diverging the room.
   - server → client on connect: `{type: "roomstate", state, seq,
 recentActionIds}`.
 - Client-side `SyncManager` (`src/party/sync-manager.ts`) maintains the core
@@ -119,13 +124,24 @@ concurrent actions in different orders.
 - Unlocks: undo, audit ("who deleted that drawing"), time-travel debugging.
 - Add `{type: "hello", protocolVersion}` handshake; server can tell outdated
   clients to refresh via the existing update-manager flow.
+- **Durability signal (not yet implemented).** `reject` closes the gap for
+  actions the reducer refuses, but an action that applies cleanly and then
+  fails to _persist_ is still confirmed to the client with nothing to take it
+  back: `storage.put` is fire-and-forget and the Supabase upsert's error is
+  returned rather than thrown. A `{type:"persisted", seq}` emitted once a write
+  settles would let clients see how far the durable snapshot has actually
+  advanced and surface a warning when it stalls behind the applied seq — the
+  failure mode where edits look fine until a reconnect reverts everyone to an
+  old checkpoint. Worth folding into this step, since it reworks persistence
+  anyway.
 
 ### Step 4 — trust boundary
 
 - Server currently dispatches whatever clients send. Notably a forged
   `party/supplyState` action would overwrite the whole room via the root
   reducer's state-replacement branch. Whitelist allowed action types
-  server-side.
+  server-side. The `reject` message is already in place to carry the refusal
+  back to the sender, so this step only needs the policy, not new protocol.
 - Room secret / role tokens: organizer (write) vs viewer + OBS sources
   (read-only).
 

--- a/src/assets/i18n.json
+++ b/src/assets/i18n.json
@@ -111,7 +111,8 @@
       "disconnected": "Lost connection to the event server. Changes are disabled until reconnected.",
       "reconnected": "Reconnected to the event server!",
       "actionBlocked": "Still reconnecting to the event server. Your change was not applied.",
-      "sendFailed": "A change could not be delivered to the event server after several attempts."
+      "sendFailed": "A change could not be delivered to the event server after several attempts.",
+      "actionRejected": "A change was rejected by the event server and has been undone."
     },
     "error": {
       "title": "Error Caught!",
@@ -226,7 +227,8 @@
       "disconnected": "イベントサーバーとの接続が切断されました。再接続するまで変更できません。",
       "reconnected": "イベントサーバーに再接続しました！",
       "actionBlocked": "イベントサーバーに再接続中のため、変更は適用されませんでした。",
-      "sendFailed": "複数回試みましたが、変更をイベントサーバーへ送信できませんでした。"
+      "sendFailed": "複数回試みましたが、変更をイベントサーバーへ送信できませんでした。",
+      "actionRejected": "イベントサーバーが変更を拒否したため、元に戻しました。"
     },
     "error": {
       "title": "エラーが発生しました！",

--- a/src/party/client.tsx
+++ b/src/party/client.tsx
@@ -22,6 +22,11 @@ const HEALTH_TOAST_KEY = "party-connection-health";
 const BLOCKED_TOAST_KEY = "party-action-blocked";
 const SEND_FAILED_TOAST_KEY = "party-action-send-failed";
 
+/** how often to ping the server to prove the socket is really alive */
+const HEARTBEAT_INTERVAL_MS = 10000;
+/** consecutive unanswered pings that mean a stalled (half-open) connection */
+const MAX_MISSED_PONGS = 2;
+
 export function PartySocketManager(props: {
   roomName?: string;
   children: React.ReactNode;
@@ -35,6 +40,9 @@ export function PartySocketManager(props: {
   // so we only announce a reconnect after announcing a disconnect
   const disconnectedRef = useRef(false);
   const syncRef = useRef<SyncManager | null>(null);
+  // consecutive heartbeats sent without a pong back; a stalled-but-open
+  // socket (server frozen, half-open TCP) is otherwise invisible
+  const missedPongsRef = useRef(0);
   // keeps the sync manager's give-up toast bound to the current locale
   // without recreating it (which would drop pending actions)
   const sendFailedToast = useRef(() => {});
@@ -56,6 +64,7 @@ export function PartySocketManager(props: {
               ),
             );
             // dispatch stays blocked until the resync above is complete
+            missedPongsRef.current = 0;
             setPartyConnectionHealthy(true);
             if (disconnectedRef.current) {
               disconnectedRef.current = false;
@@ -75,8 +84,14 @@ export function PartySocketManager(props: {
           case "action":
             syncRef.current?.handleRemoteAction(data);
             break;
+          case "catchup":
+            syncRef.current?.handleCatchup(data.actions);
+            break;
           case "ack":
             syncRef.current?.handleAck(data.id);
+            break;
+          case "pong":
+            missedPongsRef.current = 0;
             break;
         }
       } catch (e) {
@@ -148,6 +163,9 @@ export function PartySocketManager(props: {
       applyState(state) {
         dispatch(receivePartyState(state));
       },
+      requestCatchup(since) {
+        socket.send(JSON.stringify({ type: "catchup", since }));
+      },
       resync() {
         socket.reconnect();
       },
@@ -179,6 +197,25 @@ export function PartySocketManager(props: {
       syncRef.current = null;
     };
   }, [socket, dispatch]);
+
+  // Application-level heartbeat: a websocket can stay OPEN while the server is
+  // frozen or the TCP link is half-open, in which case nothing surfaces the
+  // dead connection until an ack times out. Ping periodically and force a
+  // reconnect once too many pongs go unanswered.
+  useEffect(() => {
+    missedPongsRef.current = 0;
+    const interval = setInterval(() => {
+      if (socket.readyState !== WebSocket.OPEN) return;
+      if (missedPongsRef.current >= MAX_MISSED_PONGS) {
+        missedPongsRef.current = 0;
+        socket.reconnect();
+        return;
+      }
+      missedPongsRef.current += 1;
+      socket.send(JSON.stringify({ type: "ping" }));
+    }, HEARTBEAT_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [socket]);
 
   if (!ready) {
     return (

--- a/src/party/client.tsx
+++ b/src/party/client.tsx
@@ -21,6 +21,7 @@ import { SyncManager } from "./sync-manager";
 const HEALTH_TOAST_KEY = "party-connection-health";
 const BLOCKED_TOAST_KEY = "party-action-blocked";
 const SEND_FAILED_TOAST_KEY = "party-action-send-failed";
+const REJECTED_TOAST_KEY = "party-action-rejected";
 
 /** how often to ping the server to prove the socket is really alive */
 const HEARTBEAT_INTERVAL_MS = 10000;
@@ -46,6 +47,8 @@ export function PartySocketManager(props: {
   // keeps the sync manager's give-up toast bound to the current locale
   // without recreating it (which would drop pending actions)
   const sendFailedToast = useRef(() => {});
+  // same, for an action the server refused outright
+  const rejectedToast = useRef((_reason: string) => {});
 
   const socket = usePartySocket({
     room: props.roomName,
@@ -89,6 +92,9 @@ export function PartySocketManager(props: {
             break;
           case "ack":
             syncRef.current?.handleAck(data.id);
+            break;
+          case "reject":
+            syncRef.current?.handleReject(data.id, data.reason);
             break;
           case "pong":
             missedPongsRef.current = 0;
@@ -139,6 +145,19 @@ export function PartySocketManager(props: {
         SEND_FAILED_TOAST_KEY,
       );
     };
+    rejectedToast.current = (reason: string) => {
+      // the reason is server-side detail; log it for debugging but keep the
+      // toast to something a tournament organizer can act on
+      console.warn("event server rejected an action:", reason);
+      if (inObs) return;
+      toaster.show(
+        {
+          message: t("party.actionRejected"),
+          intent: Intent.DANGER,
+        },
+        REJECTED_TOAST_KEY,
+      );
+    };
     return () => {
       setBlockedActionHandler(undefined);
     };
@@ -151,6 +170,7 @@ export function PartySocketManager(props: {
       toaster.dismiss(HEALTH_TOAST_KEY);
       toaster.dismiss(BLOCKED_TOAST_KEY);
       toaster.dismiss(SEND_FAILED_TOAST_KEY);
+      toaster.dismiss(REJECTED_TOAST_KEY);
     };
   }, []);
 
@@ -171,6 +191,9 @@ export function PartySocketManager(props: {
       },
       onGiveUp() {
         sendFailedToast.current();
+      },
+      onReject(_action, reason) {
+        rejectedToast.current(reason);
       },
     });
     syncRef.current = sync;

--- a/src/party/server.ts
+++ b/src/party/server.ts
@@ -1,5 +1,14 @@
 import type * as Party from "partykit/server";
-import type { ActionAck, ReduxAction, Roomstate } from "./types";
+import type {
+  ActionAck,
+  CatchupRequest,
+  CatchupResponse,
+  ClientMessage,
+  Pong,
+  ReduxAction,
+  Roomstate,
+  StampedAction,
+} from "./types";
 import { configureStore } from "@reduxjs/toolkit";
 import { reducer } from "../state/root-reducer";
 import type { AppState } from "../state/store";
@@ -32,6 +41,16 @@ function isAppState(state: unknown): state is AppState {
 
 /** upper bound on remembered action ids used to dedupe client re-sends */
 const MAX_REMEMBERED_ACTIONS = 1000;
+/** how many recent stamped actions to retain for incremental catch-up */
+const MAX_TAIL = 500;
+/** storage key holding the sequencer counter + dedupe set (survives hibernation) */
+const SYNC_META_KEY = "syncMeta";
+
+/** shape of the persisted sequencer metadata */
+interface SyncMeta {
+  seq: number;
+  seenIds: string[];
+}
 
 export default class Server implements Party.Server {
   // @ts-expect-error I assign this for sure
@@ -42,6 +61,15 @@ export default class Server implements Party.Server {
 
   /** recently applied action ids mapped to their seq, oldest first */
   private seenActionIds = new Map<string, number>();
+
+  /**
+   * tail of recently stamped actions (ascending seq) used to answer catch-up
+   * requests. In-memory only: a client only asks for catch-up after seeing a
+   * gap on a *live* socket, which means this actor has been running the whole
+   * time and the tail is intact. A restart/hibernation drops every socket, so
+   * clients reconnect and take a fresh roomstate instead of catching up.
+   */
+  private tail: StampedAction[] = [];
 
   constructor(readonly room: Party.Room) {
     console.log("constructor start");
@@ -59,6 +87,16 @@ export default class Server implements Party.Server {
     } else {
       this.store = configureStore({ reducer });
     }
+    // restore the sequencer counter + dedupe set so a hibernated/restarted
+    // room doesn't reset seq to 0 or forget which ids it already applied
+    // (which would let a client's re-send be applied a second time)
+    try {
+      const meta = await this.room.storage.get<SyncMeta>(SYNC_META_KEY);
+      if (meta) {
+        this.seq = meta.seq;
+        this.seenActionIds = new Map(meta.seenIds.map((id) => [id, meta.seq]));
+      }
+    } catch {}
   }
 
   private async getFromSupabase() {
@@ -98,19 +136,35 @@ export default class Server implements Party.Server {
     );
 
     // send the initial state to this client
-    conn.send(
-      JSON.stringify(<Roomstate>{
-        type: "roomstate",
-        state: this.store.getState(),
-        recentActionIds: Array.from(this.seenActionIds.keys()),
-        seq: this.seq,
-      }),
-    );
+    conn.send(JSON.stringify(this.roomstateMessage()));
   }
 
   async onMessage(message: string, sender: Party.Connection) {
-    const parsed = JSON.parse(message) as ReduxAction;
+    let parsed: ClientMessage;
+    try {
+      parsed = JSON.parse(message) as ClientMessage;
+    } catch {
+      return;
+    }
 
+    switch (parsed.type) {
+      case "ping":
+        sender.send(JSON.stringify(<Pong>{ type: "pong" }));
+        return;
+      case "catchup":
+        this.handleCatchup(parsed, sender);
+        return;
+      case "action":
+        await this.handleAction(parsed, sender, message);
+        return;
+    }
+  }
+
+  private async handleAction(
+    parsed: ReduxAction,
+    sender: Party.Connection,
+    rawMessage: string,
+  ) {
     if (parsed.id && this.seenActionIds.has(parsed.id)) {
       // a re-send of an action already applied: confirm receipt again
       // (the original ack may have been lost) but don't apply it twice
@@ -123,23 +177,32 @@ export default class Server implements Party.Server {
       // everyone *including* the sender: the echo doubles as the receipt
       // confirmation, and all replicas apply actions in seq order
       this.seq += 1;
-      const stamped: ReduxAction = { ...parsed, seq: this.seq };
+      const stamped: StampedAction = {
+        ...parsed,
+        id: parsed.id,
+        seq: this.seq,
+      };
+      this.rememberStampedAction(stamped);
       this.room.broadcast(JSON.stringify(stamped));
     } else {
       // legacy client that can't recognize its own echo: relay the
       // unstamped action to everyone else only
-      this.room.broadcast(message, [sender.id]);
+      this.room.broadcast(rawMessage, [sender.id]);
     }
 
     // resolve the new state
     this.store.dispatch(parsed.action);
     const nextState = this.store.getState();
-    // persist to partykit storage
+    // persist to partykit storage: the state itself, plus the sequencer
+    // metadata so dedupe/ordering survive a hibernation or restart
     void this.room.storage.put("currentState", nextState);
-
     if (parsed.id) {
-      this.rememberActionId(parsed.id);
+      void this.room.storage.put<SyncMeta>(SYNC_META_KEY, {
+        seq: this.seq,
+        seenIds: Array.from(this.seenActionIds.keys()),
+      });
     }
+
     // persist the state to supabase
     try {
       if (supabase) {
@@ -154,12 +217,50 @@ export default class Server implements Party.Server {
     }
   }
 
+  /**
+   * Serve a client's catch-up request: replay the stamped actions after
+   * `since`. If the gap reaches back further than our retained tail, fall
+   * back to a full roomstate so the client resyncs wholesale.
+   */
+  private handleCatchup(req: CatchupRequest, sender: Party.Connection) {
+    if (req.since >= this.seq) {
+      // client is already current (or ahead); nothing to replay
+      sender.send(
+        JSON.stringify(<CatchupResponse>{ type: "catchup", actions: [] }),
+      );
+      return;
+    }
+    const earliest = this.tail.length ? this.tail[0].seq : Infinity;
+    if (req.since >= earliest - 1) {
+      const actions = this.tail.filter((a) => a.seq > req.since);
+      sender.send(
+        JSON.stringify(<CatchupResponse>{ type: "catchup", actions }),
+      );
+    } else {
+      // the gap predates our tail; only a fresh snapshot can repair the client
+      sender.send(JSON.stringify(this.roomstateMessage()));
+    }
+  }
+
+  private roomstateMessage(): Roomstate {
+    return {
+      type: "roomstate",
+      state: this.store.getState(),
+      recentActionIds: Array.from(this.seenActionIds.keys()),
+      seq: this.seq,
+    };
+  }
+
   private sendAck(conn: Party.Connection, id: string) {
     conn.send(JSON.stringify(<ActionAck>{ type: "ack", id }));
   }
 
-  private rememberActionId(id: string) {
-    this.seenActionIds.set(id, this.seq);
+  private rememberStampedAction(stamped: StampedAction) {
+    this.tail.push(stamped);
+    if (this.tail.length > MAX_TAIL) {
+      this.tail.shift();
+    }
+    this.seenActionIds.set(stamped.id, stamped.seq);
     if (this.seenActionIds.size > MAX_REMEMBERED_ACTIONS) {
       for (const oldest of this.seenActionIds.keys()) {
         this.seenActionIds.delete(oldest);

--- a/src/party/server.ts
+++ b/src/party/server.ts
@@ -1,6 +1,7 @@
 import type * as Party from "partykit/server";
 import type {
   ActionAck,
+  ActionReject,
   CatchupRequest,
   CatchupResponse,
   ClientMessage,
@@ -172,6 +173,27 @@ export default class Server implements Party.Server {
       return;
     }
 
+    // Apply the action *before* ordering or broadcasting it. The echo doubles
+    // as the receipt confirmation, so anything broadcast is a promise that the
+    // server applied it; ordering first would let an action that the reducer
+    // refuses reach every peer (and, since step 2, enter the catch-up tail and
+    // recentActionIds) while the server's own store never took it — leaving
+    // the server silently behind every client until the next roomstate
+    // reverted them all.
+    try {
+      this.store.dispatch(parsed.action);
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      console.warn(
+        `rejecting action ${parsed.action?.type} in room ${this.room.id}:`,
+        e,
+      );
+      // seq is not consumed, the id is not remembered, nothing is broadcast:
+      // the room is exactly as it was before this message arrived
+      if (parsed.id) this.sendReject(sender, parsed.id, reason);
+      return;
+    }
+
     if (parsed.id) {
       // stamp the action with its canonical position and broadcast to
       // everyone *including* the sender: the echo doubles as the receipt
@@ -186,12 +208,11 @@ export default class Server implements Party.Server {
       this.room.broadcast(JSON.stringify(stamped));
     } else {
       // legacy client that can't recognize its own echo: relay the
-      // unstamped action to everyone else only
+      // unstamped action to everyone else only. It has no ack channel, so a
+      // rejection can only be silent for these.
       this.room.broadcast(rawMessage, [sender.id]);
     }
 
-    // resolve the new state
-    this.store.dispatch(parsed.action);
     const nextState = this.store.getState();
     // persist to partykit storage: the state itself, plus the sequencer
     // metadata so dedupe/ordering survive a hibernation or restart
@@ -253,6 +274,10 @@ export default class Server implements Party.Server {
 
   private sendAck(conn: Party.Connection, id: string) {
     conn.send(JSON.stringify(<ActionAck>{ type: "ack", id }));
+  }
+
+  private sendReject(conn: Party.Connection, id: string, reason: string) {
+    conn.send(JSON.stringify(<ActionReject>{ type: "reject", id, reason }));
   }
 
   private rememberStampedAction(stamped: StampedAction) {

--- a/src/party/sync-manager.ts
+++ b/src/party/sync-manager.ts
@@ -2,12 +2,16 @@ import { nanoid } from "nanoid";
 import type { Action } from "@reduxjs/toolkit";
 import { reducer } from "../state/root-reducer";
 import type { AppState } from "../state/store";
-import type { ReduxAction, Roomstate } from "./types";
+import type { ReduxAction, Roomstate, StampedAction } from "./types";
 
 /** how long to wait for the server to confirm receipt before re-sending */
 const ACK_TIMEOUT_MS = 5000;
 /** total transmissions per action on a live connection before giving up */
 const MAX_SEND_ATTEMPTS = 4;
+/** how long to wait for a catch-up reply before re-asking */
+const CATCHUP_TIMEOUT_MS = 5000;
+/** catch-up requests before falling back to a full reconnect */
+const MAX_CATCHUP_ATTEMPTS = 3;
 
 interface SocketLike {
   readyState: number;
@@ -34,16 +38,26 @@ interface PendingEntry {
  *   sends re-transmit on a timeout (the server dedupes by id) and anything
  *   still pending across a reconnect is rebased onto the fresh roomstate.
  *
+ * When a gap in `seq` is observed on a live socket (a missed broadcast), the
+ * manager repairs incrementally: it asks the server to replay the missing
+ * stamped actions (catch-up) rather than tearing down the socket for a full
+ * snapshot. Broadcasts that arrive while the repair is in flight are buffered
+ * and replayed once the gap is filled.
+ *
  * Against a server that predates seq stamping (`lastSeq == null`), this
  * degrades to plain optimistic apply with ack-based pending tracking:
- * no rebasing, no give-up rollback.
+ * no rebasing, no give-up rollback, no catch-up.
  */
 export class SyncManager {
   private pending = new Map<string, PendingEntry>();
   private confirmed: AppState | null = null;
   private lastSeq: number | null = null;
-  /** true from detecting a missed broadcast until the repairing roomstate */
+  /** true from detecting a missed broadcast until the repair completes */
   private resyncing = false;
+  /** live broadcasts received while a catch-up repair is in flight */
+  private buffer: ReduxAction[] = [];
+  private catchupTimer?: ReturnType<typeof setTimeout>;
+  private catchupAttempts = 0;
 
   constructor(
     private socket: SocketLike,
@@ -52,7 +66,9 @@ export class SyncManager {
       dispatchForeign: (action: Action) => void;
       /** replace the display store state wholesale after a rebase */
       applyState: (state: AppState) => void;
-      /** a broadcast was missed; only a fresh roomstate can repair us */
+      /** ask the server to replay every stamped action after `since` */
+      requestCatchup: (since: number) => void;
+      /** repair could not proceed incrementally; force a fresh roomstate */
       resync: () => void;
       /** an action was abandoned after repeated unconfirmed sends */
       onGiveUp: (action: Action) => void;
@@ -70,13 +86,15 @@ export class SyncManager {
   }
 
   /**
-   * A fresh roomstate arrived (initial connect, reconnect, or repair).
-   * Adopts it as the confirmed state, drops pending actions the server
-   * already applied, and re-sends the rest. Returns the state the display
-   * store should show: confirmed with remaining pending rebased on top.
+   * A fresh roomstate arrived (initial connect, reconnect, or catch-up
+   * fallback). Adopts it as the confirmed state, drops pending actions the
+   * server already applied, and re-sends the rest. Returns the state the
+   * display store should show: confirmed with remaining pending rebased on top.
    */
   handleRoomstate(roomstate: Roomstate): AppState {
-    this.resyncing = false;
+    this.endCatchup();
+    // a full snapshot supersedes anything buffered mid-repair
+    this.buffer = [];
     this.confirmed = roomstate.state;
     this.lastSeq = roomstate.seq ?? null;
     const applied = new Set(roomstate.recentActionIds ?? []);
@@ -98,7 +116,6 @@ export class SyncManager {
    * Advances the confirmed state and keeps the display state consistent.
    */
   handleRemoteAction(message: ReduxAction) {
-    if (this.resyncing) return;
     if (!this.confirmed) {
       // roomstate always precedes broadcasts on a connection, so this is
       // unreachable; degrade gracefully if it somehow isn't
@@ -107,6 +124,53 @@ export class SyncManager {
       }
       return;
     }
+    if (this.resyncing) {
+      // hold live broadcasts until the in-flight catch-up fills the gap
+      if (message.seq != null) this.buffer.push(message);
+      return;
+    }
+    this.ingest(message);
+  }
+
+  /**
+   * The server replayed the stamped actions filling a detected gap. Apply
+   * them in order, then drain any live broadcasts buffered during the repair.
+   */
+  handleCatchup(actions: StampedAction[]) {
+    if (!this.confirmed) return;
+    this.endCatchup();
+    for (const message of actions) {
+      if (this.resyncing) {
+        // a further gap opened mid-replay; buffer the rest for the next round
+        this.buffer.push(message);
+        continue;
+      }
+      this.ingest(message);
+    }
+    if (!this.resyncing) this.drainBuffer();
+  }
+
+  /** the server says this id was applied earlier (duplicate re-send) */
+  handleAck(id: string) {
+    this.settle(id);
+  }
+
+  /** count of actions awaiting confirmation */
+  get pendingCount() {
+    return this.pending.size;
+  }
+
+  dispose() {
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+    }
+    this.pending.clear();
+    this.endCatchup();
+    this.buffer = [];
+  }
+
+  /** apply a single stamped/foreign broadcast, maintaining the invariant */
+  private ingest(message: ReduxAction) {
     if (message.seq != null && this.lastSeq != null) {
       if (message.seq <= this.lastSeq) {
         // stale re-delivery of something already reflected in confirmed
@@ -114,15 +178,16 @@ export class SyncManager {
         return;
       }
       if (message.seq > this.lastSeq + 1) {
-        this.resyncing = true;
-        this.handlers.resync();
+        // a broadcast went missing: buffer this one and repair incrementally
+        this.buffer.push(message);
+        this.startCatchup();
         return;
       }
     }
     if (message.seq != null) {
       this.lastSeq = message.seq;
     }
-    this.confirmed = reducer(this.confirmed, message.action);
+    this.confirmed = reducer(this.confirmed!, message.action);
 
     const ownEntry = message.id ? this.pending.get(message.id) : undefined;
     if (ownEntry) {
@@ -144,21 +209,46 @@ export class SyncManager {
     }
   }
 
-  /** the server says this id was applied earlier (duplicate re-send) */
-  handleAck(id: string) {
-    this.settle(id);
+  /** begin (or continue) an incremental catch-up for the current gap */
+  private startCatchup() {
+    this.resyncing = true;
+    this.catchupAttempts = 0;
+    this.sendCatchup();
   }
 
-  /** count of actions awaiting confirmation */
-  get pendingCount() {
-    return this.pending.size;
+  private sendCatchup() {
+    this.catchupAttempts += 1;
+    this.handlers.requestCatchup(this.lastSeq!);
+    clearTimeout(this.catchupTimer);
+    this.catchupTimer = setTimeout(() => {
+      if (!this.resyncing) return;
+      if (this.catchupAttempts >= MAX_CATCHUP_ATTEMPTS) {
+        // catch-up isn't getting through; fall back to a full reconnect
+        this.endCatchup();
+        this.handlers.resync();
+        return;
+      }
+      this.sendCatchup();
+    }, CATCHUP_TIMEOUT_MS);
   }
 
-  dispose() {
-    for (const entry of this.pending.values()) {
-      clearTimeout(entry.timer);
+  private endCatchup() {
+    clearTimeout(this.catchupTimer);
+    this.catchupTimer = undefined;
+    this.resyncing = false;
+  }
+
+  /** replay live broadcasts buffered during a repair, in seq order */
+  private drainBuffer() {
+    const buffered = this.buffer.splice(0).sort((a, b) => a.seq! - b.seq!);
+    for (const message of buffered) {
+      if (this.resyncing) {
+        // ingest reopened a gap; hold the remainder for the next round
+        this.buffer.push(message);
+        continue;
+      }
+      this.ingest(message);
     }
-    this.pending.clear();
   }
 
   /** replay pending actions over the confirmed state */

--- a/src/party/sync-manager.ts
+++ b/src/party/sync-manager.ts
@@ -72,6 +72,8 @@ export class SyncManager {
       resync: () => void;
       /** an action was abandoned after repeated unconfirmed sends */
       onGiveUp: (action: Action) => void;
+      /** the server refused an action outright; it will never be applied */
+      onReject: (action: Action, reason: string) => void;
     },
   ) {}
 
@@ -153,6 +155,22 @@ export class SyncManager {
   /** the server says this id was applied earlier (duplicate re-send) */
   handleAck(id: string) {
     this.settle(id);
+  }
+
+  /**
+   * The server refused an action: it was never ordered, broadcast, or applied
+   * anywhere. Roll it back out of the display state, the same way an abandoned
+   * send is rolled back — the difference is that this is definitive, so there
+   * is no point waiting out the ack timeout or re-sending.
+   */
+  handleReject(id: string, reason: string) {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.settle(id);
+    if (this.lastSeq != null && this.confirmed) {
+      this.handlers.applyState(this.rebase());
+    }
+    this.handlers.onReject(entry.message.action, reason);
   }
 
   /** count of actions awaiting confirmation */

--- a/src/party/types.ts
+++ b/src/party/types.ts
@@ -26,11 +26,54 @@ export interface ReduxAction {
   seq?: number;
 }
 
+/** a server-ordered action: an id'd action that has been assigned its seq */
+export type StampedAction = ReduxAction & { id: string; seq: number };
+
 /** the server confirms it received and applied the action with this id */
 export interface ActionAck {
   type: "ack";
   id: string;
 }
 
+/**
+ * client → server: a gap in `seq` was observed on a live socket. Asks the
+ * server to replay every stamped action after `since` so the client can
+ * repair its confirmed state without taking a whole fresh snapshot.
+ */
+export interface CatchupRequest {
+  type: "catchup";
+  /** the last seq the client has confirmed; it wants everything after it */
+  since: number;
+}
+
+/**
+ * server → client: the stamped actions filling a requested gap, ascending by
+ * seq (all with seq > the request's `since`). When the gap reaches back
+ * further than the server's retained tail, the server sends a {@link Roomstate}
+ * instead and the client resyncs wholesale.
+ */
+export interface CatchupResponse {
+  type: "catchup";
+  actions: StampedAction[];
+}
+
+/** client → server: application-level heartbeat */
+export interface Ping {
+  type: "ping";
+}
+
+/** server → client: heartbeat reply, proving the room actor is still live */
+export interface Pong {
+  type: "pong";
+}
+
+/** All messages a client may send to the server */
+export type ClientMessage = ReduxAction | CatchupRequest | Ping;
+
 /** All messages possibly sent by the server to clients */
-export type Broadcast = Roomstate | ReduxAction | ActionAck;
+export type Broadcast =
+  | Roomstate
+  | ReduxAction
+  | ActionAck
+  | CatchupResponse
+  | Pong;

--- a/src/party/types.ts
+++ b/src/party/types.ts
@@ -36,6 +36,21 @@ export interface ActionAck {
 }
 
 /**
+ * server → sender only: the action could not be applied, so it was never
+ * ordered or broadcast. The sender rolls it back out of its display state.
+ *
+ * Without this the sender has no way to learn about a failure: the echo that
+ * doubles as the ack is only sent for actions that applied, so a rejected
+ * action would otherwise sit pending until the ack timeout gives up on it.
+ */
+export interface ActionReject {
+  type: "reject";
+  id: string;
+  /** human-readable cause, for the toast and for logs */
+  reason: string;
+}
+
+/**
  * client → server: a gap in `seq` was observed on a live socket. Asks the
  * server to replay every stamped action after `since` so the client can
  * repair its confirmed state without taking a whole fresh snapshot.
@@ -75,5 +90,6 @@ export type Broadcast =
   | Roomstate
   | ReduxAction
   | ActionAck
+  | ActionReject
   | CatchupResponse
   | Pong;


### PR DESCRIPTION
## Summary

This PR implements two critical improvements to the PartyKit sync protocol to make brief network disruptions nearly free and detect stalled connections:

1. **Incremental catch-up**: When a client detects a gap in action sequence numbers on a live socket, it now asks the server to replay just the missing actions instead of forcing a full reconnect. The server maintains an in-memory tail of recent stamped actions and responds with the gap-filling actions, or falls back to a full roomstate if the gap predates the retained tail.

2. **Application-level heartbeat**: Clients now ping the server every ~10 seconds and treat 2 unanswered pings as a dead connection, forcing a reconnect. This surfaces stalled-but-open sockets (e.g., frozen server, half-open TCP) that would otherwise go unnoticed until an ack timeout.

3. **Persistent sequencer metadata**: The server now persists `seq` and the dedupe id set to room storage (`syncMeta` key) so hibernation/restarts don't reset the sequencer or forget applied ids, closing a small dedupe window.

## Key Changes

**Client (`src/party/sync-manager.ts`)**:
- Added `resyncing` flag and `buffer` array to hold live broadcasts while a catch-up repair is in flight
- New `handleCatchup()` method to apply replayed stamped actions and drain buffered broadcasts
- New `ingest()` method extracted from `handleRemoteAction()` to apply a single action with gap detection
- On gap detection, calls `requestCatchup(since)` instead of immediately calling `resync()`
- Catch-up requests retry on 5s timeout with `MAX_CATCHUP_ATTEMPTS` (3) before falling back to full reconnect
- Added `dispose()` to clean up timers and buffers

**Server (`src/party/server.ts`)**:
- Added in-memory `tail` array storing the last 500 stamped actions for catch-up replies
- New `handleCatchup()` method that returns missing actions from the tail or a full roomstate if the gap is too old
- Persists `seq` and `seenIds` to room storage under `SYNC_META_KEY` on startup and after each action
- Refactored `onMessage()` to dispatch by message type (`action`, `catchup`, `ping`)
- `rememberActionId()` renamed to `rememberStampedAction()` and now maintains the tail

**Client socket manager (`src/party/client.tsx`)**:
- Added heartbeat loop that pings every `HEARTBEAT_INTERVAL_MS` (10s)
- Tracks `missedPongsRef` and forces reconnect after `MAX_MISSED_PONGS` (2) unanswered pings
- Pong counter resets on any pong or fresh roomstate arrival
- Wired `requestCatchup()` handler to send catchup messages

**Protocol types (`src/party/types.ts`)**:
- New `StampedAction` type: a ReduxAction with guaranteed `id` and `seq`
- New `CatchupRequest` and `CatchupResponse` message types
- New `Ping` and `Pong` message types
- Updated `ClientMessage` and `Broadcast` union types

**Documentation (`docs/partykit-sync-design.md` and `docs/partykit-sync-roadmap.md`)**:
- Documented the catch-up flow, including buffer/drain mechanics and fallback to reconnect
- Explained why the tail is memory-only (safe because clients only catch up on live sockets)
- Documented the heartbeat mechanism and the stalled-socket failure mode it addresses
- Updated version interop notes: older servers ignore `catchup`/`ping` and degrade gracefully

## Notable Implementation Details

- **Buffer and drain**: While a catch-up is in flight, live broadcasts are buffered and replayed in `seq` order once the gap closes. If a gap reopens mid-drain, another catch-up round begins.
- **Memory-only tail**: The tail is deliberately not persisted to room storage. A client can only observe a live-socket gap while the same actor has been running

https://claude.ai/code/session_01Tuc1MxeNwT1rU9bxSuVMUX