### PR TITLE
Diagnostics for the stuck-room bug: party server logging, a room log watcher, and a ?debug health endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-loader": "10.0.0",
     "better-sqlite3": "12.5.0",
     "cacheable-lookup": "7.0.0",
-    "canvas": "3.2.0",
+    "canvas": "3.2.3",
     "classnames": "2.5.1",
     "clean-webpack-plugin": "4.0.0",
     "copy-webpack-plugin": "13.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "deploy:surge": "surge ./surge-redirect https://ddrdraw.surge.sh",
     "deploy:staging": "surge ./surge-redirect https://ddrdraw-staging.surge.sh",
     "format": "oxfmt",
+    "watch:room": "node scripts/watch-room.mjs",
     "import:ddr": "node --experimental-strip-types scripts/import-ddr.mts",
     "import:jubeat": "node --experimental-strip-types scripts/import-jubeat.mts",
     "import:pump": "node scripts/import-pump.mjs",

--- a/scripts/watch-room.mjs
+++ b/scripts/watch-room.mjs
@@ -1,0 +1,502 @@
+#!/usr/bin/env node
+/**
+ * Watch the deployed party server's logs for a single event room.
+ *
+ * Wraps `partykit tail`, which supports a server-side `--search` text filter.
+ * Every diagnostic line the server emits carries `room=<id>`, so searching for
+ * that string narrows the firehose to one event. The room id is the `:roomName`
+ * segment of an event URL, so you can paste the whole link a reporter sent you.
+ *
+ *   node scripts/watch-room.mjs https://ddrdraw.surge.sh/#/e/abc123
+ *   node scripts/watch-room.mjs abc123
+ *   yarn watch:room abc123
+ *
+ * Beyond filtering, this correlates the lines to answer the question the
+ * logging was added for: did the persisted snapshot stop advancing? It flags
+ * when a room restarts holding unconfirmed storage writes, and when a restart
+ * hydrates a snapshot that doesn't match the last state we saw applied.
+ *
+ * A tail session expires server-side and the partykit CLI does not reconnect,
+ * so this restarts it automatically and marks the gap. Tail has no backfill:
+ * anything logged during a gap is gone, which is why gaps are printed rather
+ * than papered over, and why findings that straddle one are qualified.
+ */
+import { spawn } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { createWriteStream, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const DIAG_PREFIX = "[party-diag]";
+/** `[party-diag] room=<id> <event> <details...>` */
+const DIAG_LINE = /^\[party-diag\] room=(\S+) (\S+)(?: ([\s\S]*))?$/;
+/** the state fingerprint the server stamps onto most lines */
+const FINGERPRINT = /drawings=\d+ stateLen=-?\d+/;
+
+const color = process.stdout.isTTY
+  ? {
+      dim: (s) => `\x1b[2m${s}\x1b[0m`,
+      red: (s) => `\x1b[31m${s}\x1b[0m`,
+      yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+      green: (s) => `\x1b[32m${s}\x1b[0m`,
+      cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+      bold: (s) => `\x1b[1m${s}\x1b[0m`,
+    }
+  : new Proxy({}, { get: () => (s) => s });
+
+function usage() {
+  console.log(`
+Watch one event room's party server logs.
+
+Usage:
+  node scripts/watch-room.mjs <room-id-or-event-url> [options] [-- <partykit args>]
+
+Options:
+  --out <file>   append the timeline to a file as well (no colour codes), so
+                 it can be parked for a whole event and read afterwards
+  --no-reconnect do not restart the tail when it drops
+  --verbose      also show non-diagnostic log lines from matching invocations
+  --raw          print raw tail JSON instead of the digested timeline
+  --all          skip the exact client-side room match (keep every matched
+                 invocation, even if another room's line tripped the search)
+  -h, --help     show this
+
+Anything after \`--\` is passed through to \`partykit tail\`, e.g.:
+  node scripts/watch-room.mjs abc123 -- --preview my-preview
+`);
+}
+
+/** accepts a bare id, a path, or a full event URL (hash routes included) */
+function extractRoomId(input) {
+  const match = /\/e\/([^/?#\s]+)/.exec(input);
+  return decodeURIComponent(match ? match[1] : input);
+}
+
+const argv = process.argv.slice(2);
+if (!argv.length || argv.includes("-h") || argv.includes("--help")) {
+  usage();
+  process.exit(argv.length ? 0 : 1);
+}
+
+const passThroughAt = argv.indexOf("--");
+const ownArgs = passThroughAt === -1 ? argv : argv.slice(0, passThroughAt);
+const tailArgs = passThroughAt === -1 ? [] : argv.slice(passThroughAt + 1);
+
+// pull `--out <file>` out before the rest, since it takes a value
+const outAt = ownArgs.indexOf("--out");
+let outPath = null;
+if (outAt !== -1) {
+  outPath = ownArgs[outAt + 1];
+  if (!outPath || outPath.startsWith("-")) {
+    console.error("error: --out requires a file path\n");
+    usage();
+    process.exit(1);
+  }
+  ownArgs.splice(outAt, 2);
+}
+
+const flags = new Set(ownArgs.filter((a) => a.startsWith("-")));
+const positional = ownArgs.filter((a) => !a.startsWith("-"));
+if (!positional.length) {
+  console.error("error: a room id or event URL is required\n");
+  usage();
+  process.exit(1);
+}
+
+const roomId = extractRoomId(positional[0]);
+const verbose = flags.has("--verbose");
+const raw = flags.has("--raw");
+const matchExactRoom = !flags.has("--all");
+const reconnect = !flags.has("--no-reconnect");
+
+/** how long a tail must survive before we treat the connection as healthy */
+const HEALTHY_MS = 10_000;
+/** consecutive immediate failures before giving up (bad auth, wrong project) */
+const MAX_FAILURES = 5;
+
+const outStream = outPath ? createWriteStream(outPath, { flags: "a" }) : null;
+const ANSI = /\x1b\[[0-9;]*m/g;
+
+/** write one line to stdout (with colour) and to --out (without) */
+function emit(line) {
+  console.log(line);
+  if (outStream) outStream.write(`${line.replace(ANSI, "")}\n`);
+}
+
+const localBin = resolve(
+  join(__dirname, "..", "node_modules", ".bin", "partykit"),
+);
+const partykitBin = existsSync(localBin) ? localBin : "partykit";
+
+console.error(
+  color.bold(`watching room ${roomId}`) +
+    color.dim(` (via ${partykitBin} tail --search "room=${roomId}")`),
+);
+if (outStream) console.error(color.dim(`appending timeline to ${outPath}`));
+console.error(color.dim("ctrl-c to stop and print a summary\n"));
+
+if (outStream) {
+  outStream.write(
+    `\n=== watch-room session started ${new Date().toISOString()} room=${roomId} ===\n`,
+  );
+}
+
+/** running tallies, reported on exit */
+const counts = new Map();
+const alerts = [];
+/** number of times the tail dropped and was restarted */
+let reconnects = 0;
+/**
+ * set when a tail gap means we may have missed events since the current
+ * baseline was established; cleared once a fresh action re-establishes it.
+ * Findings that depend on the baseline are qualified while this is set.
+ */
+let gapSinceBaseline = false;
+/** puts that were in flight when a gap began: they may have settled unseen */
+let putsUnknown = 0;
+/** working baseline: the state we believe is current, re-based on each onStart */
+let lastApplied = null;
+let lastAppliedSeq = null;
+/** high-water mark: the last state a handleAction actually produced */
+let lastAction = null;
+let lastActionSeq = null;
+/** storage writes started but not yet seen confirmed on this room instance */
+let unconfirmedPuts = 0;
+let putStarts = 0;
+let putSettled = 0;
+
+function tally(key) {
+  counts.set(key, (counts.get(key) ?? 0) + 1);
+}
+
+function alert(message, dependsOnBaseline = false) {
+  const qualified =
+    dependsOnBaseline && gapSinceBaseline
+      ? `${message} [uncertain: the tail dropped since the last observed action, so events may have been missed]`
+      : message;
+  alerts.push(qualified);
+  emit(`${color.red("!! ALERT")} ${qualified}`);
+}
+
+function fingerprintOf(details) {
+  const match = FINGERPRINT.exec(details ?? "");
+  return match ? match[0] : null;
+}
+
+function fieldOf(details, name) {
+  const match = new RegExp(`${name}=(\\S+)`).exec(details ?? "");
+  return match ? match[1] : null;
+}
+
+function stamp(ms) {
+  const d = ms ? new Date(ms) : new Date();
+  return color.dim(d.toISOString().slice(11, 19));
+}
+
+/** render one console.log argument from a tail event */
+function formatPart(part) {
+  if (typeof part === "string") return part;
+  try {
+    return JSON.stringify(part);
+  } catch {
+    return String(part);
+  }
+}
+
+function handleDiagLine(text, ts) {
+  const match = DIAG_LINE.exec(text);
+  if (!match) return false;
+  const [, room, event, details = ""] = match;
+  if (matchExactRoom && room !== roomId) return true;
+
+  tally(event);
+  const fingerprint = fingerprintOf(details);
+
+  const isError =
+    event.endsWith(":error") ||
+    event.endsWith(":throw") ||
+    event === "onError" ||
+    event === "onStart:hydrate-error";
+  if (isError) {
+    alert(`${event} ${details}`);
+    // still settle the write below so the confirmed tally stays accurate
+    if (event === "storage.put:error") {
+      putSettled += 1;
+      unconfirmedPuts = Math.max(0, unconfirmedPuts - 1);
+    }
+    return true;
+  }
+
+  // print the line before analysing it, so any alert reads as a consequence
+  const label = event.padEnd(20);
+  const tint = event === "handleAction" ? color.cyan : color.dim;
+  emit(`${stamp(ts)} ${tint(label)} ${details}`);
+
+  switch (event) {
+    case "handleAction":
+      lastApplied = fingerprint ?? lastApplied;
+      lastAppliedSeq = fieldOf(details, "seq") ?? lastAppliedSeq;
+      lastAction = lastApplied;
+      lastActionSeq = lastAppliedSeq;
+      // a freshly observed action gives us a trustworthy baseline again
+      gapSinceBaseline = false;
+      break;
+
+    case "storage.put:start":
+      putStarts += 1;
+      unconfirmedPuts += 1;
+      break;
+
+    case "storage.put:ok":
+      putSettled += 1;
+      unconfirmedPuts = Math.max(0, unconfirmedPuts - 1);
+      break;
+
+    case "onStart": {
+      // a fresh instance means the previous one went away: anything it had in
+      // flight never reported back, which is the eviction/flush suspicion.
+      if (unconfirmedPuts > 0) {
+        alert(
+          `room restarted with ${unconfirmedPuts} storage write(s) never confirmed — ` +
+            `writes may not be flushing before eviction`,
+          true,
+        );
+      }
+      if (lastApplied && fingerprint && fingerprint !== lastApplied) {
+        alert(
+          `hydrated snapshot does not match last applied state — ` +
+            `SNAPSHOT REVERTED (last applied: ${lastApplied} seq=${lastAppliedSeq}; ` +
+            `hydrated from ${fieldOf(details, "source")}: ${fingerprint})`,
+          true,
+        );
+      }
+      // re-baseline against the new instance
+      unconfirmedPuts = 0;
+      lastApplied = fingerprint;
+      lastAppliedSeq = fieldOf(details, "seq");
+      break;
+    }
+
+    case "onConnect":
+      if (lastApplied && fingerprint && fingerprint !== lastApplied) {
+        alert(
+          `serving a roomstate that differs from the last applied state ` +
+            `(last applied: ${lastApplied}; serving: ${fingerprint})`,
+          true,
+        );
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  return true;
+}
+
+function handleEvent(evt) {
+  const eventTs = evt.eventTimestamp;
+
+  if (evt.outcome && evt.outcome !== "ok") {
+    tally(`outcome:${evt.outcome}`);
+    alert(`invocation outcome=${evt.outcome} (room may have been torn down)`);
+  }
+
+  for (const ex of Array.isArray(evt.exceptions) ? evt.exceptions : []) {
+    tally("exception");
+    alert(`uncaught ${ex.name ?? "exception"}: ${ex.message ?? ""}`);
+  }
+
+  for (const log of Array.isArray(evt.logs) ? evt.logs : []) {
+    const parts = Array.isArray(log.message) ? log.message : [log.message];
+    const text = parts.map(formatPart).join(" ");
+    const ts = log.timestamp ?? eventTs;
+
+    if (text.startsWith(DIAG_PREFIX)) {
+      handleDiagLine(text, ts);
+    } else if (verbose) {
+      emit(`${stamp(ts)} ${color.dim("(other)".padEnd(20))} ${text}`);
+    }
+  }
+}
+
+// `partykit tail -f json` emits JSON.stringify(event, null, 2) per event, so a
+// top-level closing brace at column 0 delimits each one.
+let buffer = "";
+
+function onChunk(chunk) {
+  if (raw) {
+    process.stdout.write(chunk);
+    return;
+  }
+  buffer += chunk;
+  let end;
+  while ((end = buffer.indexOf("\n}\n")) !== -1) {
+    const block = buffer.slice(0, end + 2);
+    buffer = buffer.slice(end + 3);
+    try {
+      handleEvent(JSON.parse(block));
+    } catch {
+      // a partial or unexpected payload: surface it rather than dying
+      console.error(color.yellow(`(could not parse tail event)`));
+    }
+  }
+}
+
+function summarize() {
+  emit(`\n${color.bold(`summary for room ${roomId}`)}`);
+  if (counts.size) {
+    for (const [event, n] of [...counts].sort((a, b) => b[1] - a[1])) {
+      emit(`  ${String(n).padStart(5)}  ${event}`);
+    }
+  } else {
+    emit(color.dim("  no matching log lines seen"));
+  }
+
+  const unsettled = putStarts - putSettled - putsUnknown;
+  // only claim everything is accounted for when nothing is unsettled *and*
+  // nothing was left in an unknown state by a tail gap
+  let writeVerdict = "";
+  if (unsettled > 0) {
+    writeVerdict = color.red(
+      ` — ${unsettled} never settled (likely lost to eviction)`,
+    );
+  } else if (putsUnknown === 0) {
+    writeVerdict = color.green(" — all accounted for");
+  }
+  emit(
+    `\n  storage writes: ${putStarts} started, ${putSettled} reported back${writeVerdict}`,
+  );
+  if (putsUnknown > 0) {
+    emit(
+      color.yellow(
+        `  ${putsUnknown} write(s) were in flight when the tail dropped — outcome unknown`,
+      ),
+    );
+  }
+  if (lastAction) {
+    emit(
+      `  last state applied by an action: ${lastAction} seq=${lastActionSeq}`,
+    );
+  }
+  if (lastApplied && lastApplied !== lastAction) {
+    emit(
+      color.red(
+        `  currently serving:              ${lastApplied} seq=${lastAppliedSeq}`,
+      ),
+    );
+  }
+  if (reconnects > 0) {
+    emit(
+      color.yellow(
+        `  tail dropped and reconnected ${reconnects} time(s) — logs during those gaps were not captured`,
+      ),
+    );
+  }
+
+  if (alerts.length) {
+    emit(`\n${color.red(`${alerts.length} alert(s):`)}`);
+    for (const a of alerts) emit(`  - ${a}`);
+  } else {
+    emit(`\n${color.green("no alerts raised")}`);
+  }
+}
+
+// ---- tail supervisor: the CLI exits when its session expires, so respawn it
+
+let child = null;
+let closing = false;
+/** consecutive failures where the tail died before reaching HEALTHY_MS */
+let failures = 0;
+let startedAt = 0;
+
+function finish(code) {
+  summarize();
+  if (outStream) {
+    outStream.end(
+      `=== watch-room session ended ${new Date().toISOString()} ===\n`,
+      () => process.exit(code),
+    );
+  } else {
+    process.exit(code);
+  }
+}
+
+function spawnTail() {
+  startedAt = Date.now();
+  buffer = "";
+  child = spawn(
+    partykitBin,
+    ["tail", "-f", "json", "--search", `room=${roomId}`, ...tailArgs],
+    { stdio: ["ignore", "pipe", "inherit"] },
+  );
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", onChunk);
+
+  child.on("error", (err) => {
+    console.error(color.red(`failed to run ${partykitBin}: ${err.message}`));
+    finish(1);
+  });
+
+  child.on("close", (code) => {
+    if (closing) {
+      finish(code ?? 0);
+      return;
+    }
+    if (!reconnect) {
+      emit(color.yellow(`tail exited (code ${code}); --no-reconnect set`));
+      finish(code ?? 0);
+      return;
+    }
+
+    const lived = Date.now() - startedAt;
+    failures = lived < HEALTHY_MS ? failures + 1 : 0;
+    if (failures >= MAX_FAILURES) {
+      emit(
+        color.red(
+          `tail exited ${failures} times in a row without staying up — giving up. ` +
+            `Check that \`${partykitBin} tail\` works on its own (login, project name).`,
+        ),
+      );
+      finish(1);
+      return;
+    }
+
+    // anything still in flight may have settled unseen during the gap, so
+    // move it out of the "never settled" tally rather than alerting on it
+    if (unconfirmedPuts > 0) {
+      putsUnknown += unconfirmedPuts;
+      unconfirmedPuts = 0;
+    }
+    gapSinceBaseline = true;
+    reconnects += 1;
+
+    const delay = Math.min(30_000, 1000 * 2 ** failures);
+    emit(
+      color.yellow(
+        `--- tail dropped at ${new Date().toISOString().slice(11, 19)} (code ${code}); ` +
+          `reconnecting in ${Math.round(delay / 1000)}s — events during the gap are lost ---`,
+      ),
+    );
+    setTimeout(() => {
+      emit(
+        color.yellow(
+          `--- tail reconnected at ${new Date().toISOString().slice(11, 19)} ---`,
+        ),
+      );
+      spawnTail();
+    }, delay);
+  });
+}
+
+function shutdown() {
+  if (closing) return;
+  closing = true;
+  if (child) child.kill("SIGINT");
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+spawnTail();

--- a/src/about.tsx
+++ b/src/about.tsx
@@ -1,6 +1,7 @@
 import { FormattedMessage, useIntl } from "react-intl";
 import { ButtonGroup, AnchorButton, UL, Classes, H2 } from "@blueprintjs/core";
 import { Comment, GitBranch, Chat } from "@blueprintjs/icons";
+import { DISCORD_INVITE_URL } from "./external-links";
 
 function injectPumpoutLink(str: string) {
   const pieces = str.split("PUMPOUT");
@@ -39,7 +40,7 @@ export function About() {
         <ButtonGroup>
           <AnchorButton
             large
-            href="https://discord.gg/QPyEATsbP7"
+            href={DISCORD_INVITE_URL}
             target="_blank"
             text={t({ id: "about.discord" })}
             icon={<Comment size={20} />}

--- a/src/assets/i18n.json
+++ b/src/assets/i18n.json
@@ -124,6 +124,7 @@
         "logHeading": "Connection log",
         "empty": "Nothing recorded yet.",
         "copy": "Copy log",
+        "copyFull": "Copy full log",
         "copied": "Copied!"
       }
     },
@@ -253,6 +254,7 @@
         "logHeading": "接続ログ",
         "empty": "まだ記録がありません。",
         "copy": "ログをコピー",
+        "copyFull": "全ログをコピー",
         "copied": "コピーしました！"
       }
     },

--- a/src/assets/i18n.json
+++ b/src/assets/i18n.json
@@ -112,7 +112,20 @@
       "reconnected": "Reconnected to the event server!",
       "actionBlocked": "Still reconnecting to the event server. Your change was not applied.",
       "sendFailed": "A change could not be delivered to the event server after several attempts.",
-      "actionRejected": "A change was rejected by the event server and has been undone."
+      "actionRejected": "A change was rejected by the event server and has been undone.",
+      "diagnostics": {
+        "menuItem": "Connection diagnostics",
+        "title": "Connection diagnostics",
+        "sharePrompt": "Seeing sync problems? Copy this log and post it in a thread on the Discord server so it can be looked into.",
+        "openDiscord": "Open Discord",
+        "pending": "Changes not yet saved to the server",
+        "noPending": "None — the server has confirmed every change.",
+        "attempts": "{count} attempt(s)",
+        "logHeading": "Connection log",
+        "empty": "Nothing recorded yet.",
+        "copy": "Copy log",
+        "copied": "Copied!"
+      }
     },
     "error": {
       "title": "Error Caught!",
@@ -228,7 +241,20 @@
       "reconnected": "イベントサーバーに再接続しました！",
       "actionBlocked": "イベントサーバーに再接続中のため、変更は適用されませんでした。",
       "sendFailed": "複数回試みましたが、変更をイベントサーバーへ送信できませんでした。",
-      "actionRejected": "イベントサーバーが変更を拒否したため、元に戻しました。"
+      "actionRejected": "イベントサーバーが変更を拒否したため、元に戻しました。",
+      "diagnostics": {
+        "menuItem": "接続診断",
+        "title": "接続診断",
+        "sharePrompt": "同期に問題がありますか？このログをコピーし、Discordサーバーのスレッドに投稿してください。",
+        "openDiscord": "Discordを開く",
+        "pending": "サーバーに未保存の変更",
+        "noPending": "なし — すべての変更がサーバーで確認されました。",
+        "attempts": "{count}回試行",
+        "logHeading": "接続ログ",
+        "empty": "まだ記録がありません。",
+        "copy": "ログをコピー",
+        "copied": "コピーしました！"
+      }
     },
     "error": {
       "title": "エラーが発生しました！",

--- a/src/external-links.ts
+++ b/src/external-links.ts
@@ -1,0 +1,7 @@
+/**
+ * Outbound links to community/project resources, kept in one place so the same
+ * URL doesn't drift between the places that offer it.
+ */
+
+/** community Discord, offered in the about dialog and the diagnostics panel */
+export const DISCORD_INVITE_URL = "https://discord.gg/QPyEATsbP7";

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -13,6 +13,7 @@ import {
   Menu as MenuIcon,
   Help,
   Control,
+  Pulse,
 } from "@blueprintjs/icons";
 import { JSX, useCallback, useState } from "react";
 import { About } from "./about";
@@ -24,6 +25,8 @@ import { useAppDispatch, useAppState } from "./state/store";
 import { drawingsSlice } from "./state/drawings.slice";
 import { EventModeGated } from "./common-components/app-mode";
 import { useNavigate, useHref } from "react-router-dom";
+import { DiagnosticsDialog } from "./party/diagnostics-dialog";
+import { useRoomName } from "./hooks/useRoomName";
 
 export function Header({
   heading,
@@ -68,6 +71,8 @@ export function Header({
 
 export function HamburgerMenu() {
   const [aboutOpen, setAboutOpen] = useState(false);
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  const roomName = useRoomName();
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const dashHref = useHref("dash", { relative: "route" });
@@ -95,6 +100,14 @@ export function HamburgerMenu() {
         text={t("clearDrawings")}
         disabled={!haveDrawings}
       />
+      <EventModeGated>
+        <MenuItem
+          icon={<Pulse />}
+          onClick={() => setDiagnosticsOpen(true)}
+          text={t("party.diagnostics.menuItem")}
+          data-umami-event="party-diagnostics-open"
+        />
+      </EventModeGated>
       <MenuItem
         icon={<InfoSign />}
         onClick={() => setAboutOpen(true)}
@@ -116,6 +129,11 @@ export function HamburgerMenu() {
       <Dialog isOpen={aboutOpen} onClose={() => setAboutOpen(false)}>
         <About />
       </Dialog>
+      <DiagnosticsDialog
+        isOpen={diagnosticsOpen}
+        onClose={() => setDiagnosticsOpen(false)}
+        roomName={roomName}
+      />
       <Popover content={menu} placement="bottom-start">
         <Button icon={<MenuIcon />} data-umami-event="hamburger-menu-open" />
       </Popover>

--- a/src/party/client.tsx
+++ b/src/party/client.tsx
@@ -17,6 +17,7 @@ import {
   setPartyConnectionHealthy,
 } from "./connection-status";
 import { SyncManager } from "./sync-manager";
+import { logDiagnostic, setPendingActionsProvider } from "./diagnostics";
 
 const HEALTH_TOAST_KEY = "party-connection-health";
 const BLOCKED_TOAST_KEY = "party-action-blocked";
@@ -59,6 +60,10 @@ export function PartySocketManager(props: {
         switch (data.type) {
           case "roomstate":
             applyMigrations(data.state);
+            logDiagnostic(
+              disconnectedRef.current ? "reconnected" : "connected",
+              `received room state (seq ${data.seq ?? "n/a"})`,
+            );
             // adopt the server state as confirmed, rebasing anything that
             // went unconfirmed before this (re)connect on top of it
             dispatch(
@@ -88,12 +93,17 @@ export function PartySocketManager(props: {
             syncRef.current?.handleRemoteAction(data);
             break;
           case "catchup":
+            logDiagnostic(
+              "catch-up",
+              `server replayed ${data.actions.length} missed change(s)`,
+            );
             syncRef.current?.handleCatchup(data.actions);
             break;
           case "ack":
             syncRef.current?.handleAck(data.id);
             break;
           case "reject":
+            logDiagnostic("action-rejected", `server refused: ${data.reason}`);
             syncRef.current?.handleReject(data.id, data.reason);
             break;
           case "pong":
@@ -106,6 +116,13 @@ export function PartySocketManager(props: {
     },
     onClose() {
       setPartyConnectionHealthy(false);
+      const stillPending = syncRef.current?.pendingCount ?? 0;
+      logDiagnostic(
+        "disconnected",
+        stillPending
+          ? `lost connection with ${stillPending} unsent change(s)`
+          : "lost connection",
+      );
       // before first sync the full-page "Connecting..." state covers this
       if (!ready || disconnectedRef.current) {
         return;
@@ -126,6 +143,7 @@ export function PartySocketManager(props: {
 
   useEffect(() => {
     setBlockedActionHandler(() => {
+      logDiagnostic("action-blocked", "change discarded while disconnected");
       if (inObs) return;
       toaster.show(
         {
@@ -187,16 +205,30 @@ export function PartySocketManager(props: {
         socket.send(JSON.stringify({ type: "catchup", since }));
       },
       resync() {
+        logDiagnostic(
+          "resync",
+          "missed changes could not be replayed in place",
+        );
         socket.reconnect();
       },
-      onGiveUp() {
+      onGiveUp(action) {
+        logDiagnostic(
+          "action-abandoned",
+          `gave up delivering ${String(action.type)} after repeated attempts`,
+        );
         sendFailedToast.current();
       },
-      onReject(_action, reason) {
+      onReject(action, reason) {
+        logDiagnostic(
+          "action-rolled-back",
+          `${String(action.type)} was undone (${reason})`,
+        );
         rejectedToast.current(reason);
       },
     });
     syncRef.current = sync;
+    // let the diagnostics panel read the live pending list without copying it
+    setPendingActionsProvider(() => sync.pendingActions);
     const stopListening = startAppListening({
       predicate(action) {
         // @ts-expect-error i don't know how to type action meta properties yet
@@ -218,8 +250,15 @@ export function PartySocketManager(props: {
       stopListening();
       sync.dispose();
       syncRef.current = null;
+      setPendingActionsProvider(undefined);
     };
   }, [socket, dispatch]);
+
+  // mark where a session begins, so a log covering several rooms or a page
+  // reload is readable
+  useEffect(() => {
+    logDiagnostic("session-started", `room ${props.roomName ?? "(none)"}`);
+  }, [props.roomName]);
 
   // Application-level heartbeat: a websocket can stay OPEN while the server is
   // frozen or the TCP link is half-open, in which case nothing surfaces the
@@ -231,6 +270,10 @@ export function PartySocketManager(props: {
       if (socket.readyState !== WebSocket.OPEN) return;
       if (missedPongsRef.current >= MAX_MISSED_PONGS) {
         missedPongsRef.current = 0;
+        logDiagnostic(
+          "heartbeat-lost",
+          `no reply to ${MAX_MISSED_PONGS} pings; forcing a reconnect`,
+        );
         socket.reconnect();
         return;
       }

--- a/src/party/diagnostics-dialog.tsx
+++ b/src/party/diagnostics-dialog.tsx
@@ -1,0 +1,185 @@
+import {
+  Button,
+  Callout,
+  Classes,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  Intent,
+  Tag,
+} from "@blueprintjs/core";
+import { Clipboard, Duplicate } from "@blueprintjs/icons";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { useIntl } from "../hooks/useIntl";
+import {
+  formatAge,
+  formatDiagnosticsReport,
+  formatTime,
+  getDiagnostics,
+  getPendingActions,
+  subscribeDiagnostics,
+} from "./diagnostics";
+
+/**
+ * Invite link for the community Discord, used by the "share these logs"
+ * prompt. Left empty until a real invite is configured — the prompt still
+ * renders (and the copy button still works), just without a clickable link,
+ * rather than shipping a URL that goes nowhere.
+ */
+const DISCORD_INVITE_URL = "";
+
+/** events that indicate something went wrong, highlighted in the list */
+const PROBLEM_EVENTS = new Set([
+  "disconnected",
+  "action-rejected",
+  "action-abandoned",
+  "action-blocked",
+  "heartbeat-lost",
+  "resync",
+]);
+
+export function DiagnosticsDialog(props: {
+  isOpen: boolean;
+  onClose: () => void;
+  roomName?: string;
+}) {
+  const { t } = useIntl();
+  const entries = useSyncExternalStore(subscribeDiagnostics, getDiagnostics);
+  const [copied, setCopied] = useState(false);
+  // pending ages tick on their own, so re-render on a timer while open
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!props.isOpen) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [props.isOpen]);
+
+  useEffect(() => {
+    if (!copied) return;
+    const id = setTimeout(() => setCopied(false), 2500);
+    return () => clearTimeout(id);
+  }, [copied]);
+
+  const pending = getPendingActions();
+
+  async function copyReport() {
+    const report = formatDiagnosticsReport(props.roomName);
+    try {
+      await navigator.clipboard.writeText(report);
+      setCopied(true);
+    } catch {
+      // clipboard can be unavailable (insecure context, denied permission):
+      // fall back to selecting the text so the user can copy it by hand
+      const area = document.getElementById(
+        "party-diagnostics-report",
+      ) as HTMLTextAreaElement | null;
+      if (area) {
+        area.select();
+        setCopied(document.execCommand("copy"));
+      }
+    }
+  }
+
+  return (
+    <Dialog
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      title={t("party.diagnostics.title")}
+      style={{ width: "min(46rem, 92vw)" }}
+    >
+      <DialogBody>
+        <Callout intent={Intent.PRIMARY} icon={<Clipboard />}>
+          {t("party.diagnostics.sharePrompt")}
+          {DISCORD_INVITE_URL ? (
+            <>
+              {" "}
+              <a href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer">
+                {t("party.diagnostics.openDiscord")}
+              </a>
+            </>
+          ) : null}
+        </Callout>
+
+        <h4 className={Classes.HEADING} style={{ marginTop: "1rem" }}>
+          {t("party.diagnostics.pending")}{" "}
+          <Tag intent={pending.length ? Intent.WARNING : Intent.SUCCESS} round>
+            {pending.length}
+          </Tag>
+        </h4>
+        {pending.length ? (
+          <ul style={{ margin: 0, paddingLeft: "1.25rem" }}>
+            {pending.map((p, i) => (
+              <li key={`${p.type}-${p.since}-${i}`}>
+                <code>{p.type}</code> — {formatAge(p.since, now)},{" "}
+                {t("party.diagnostics.attempts", { count: p.attempts })}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className={Classes.TEXT_MUTED}>
+            {t("party.diagnostics.noPending")}
+          </p>
+        )}
+
+        <h4 className={Classes.HEADING} style={{ marginTop: "1rem" }}>
+          {t("party.diagnostics.logHeading")}
+        </h4>
+        {entries.length ? (
+          <div
+            style={{
+              maxHeight: "18rem",
+              overflowY: "auto",
+              fontFamily: "monospace",
+              fontSize: "0.85em",
+              lineHeight: 1.6,
+            }}
+          >
+            {entries.map((e, i) => (
+              <div
+                key={`${e.t}-${i}`}
+                style={{
+                  color: PROBLEM_EVENTS.has(e.event) ? "#c87619" : undefined,
+                }}
+              >
+                <span className={Classes.TEXT_MUTED}>{formatTime(e.t)}</span>{" "}
+                {e.event}
+                {e.detail ? ` — ${e.detail}` : ""}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className={Classes.TEXT_MUTED}>{t("party.diagnostics.empty")}</p>
+        )}
+
+        {/* offscreen copy target for browsers without the async clipboard */}
+        <textarea
+          id="party-diagnostics-report"
+          readOnly
+          value={formatDiagnosticsReport(props.roomName)}
+          style={{
+            position: "absolute",
+            left: "-9999px",
+            width: "1px",
+            height: "1px",
+          }}
+        />
+      </DialogBody>
+      <DialogFooter
+        actions={
+          <Button
+            icon={<Duplicate />}
+            intent={copied ? Intent.SUCCESS : Intent.PRIMARY}
+            onClick={copyReport}
+            text={
+              copied
+                ? t("party.diagnostics.copied")
+                : t("party.diagnostics.copy")
+            }
+            data-umami-event="party-diagnostics-copy"
+          />
+        }
+      />
+    </Dialog>
+  );
+}

--- a/src/party/diagnostics-dialog.tsx
+++ b/src/party/diagnostics-dialog.tsx
@@ -19,14 +19,7 @@ import {
   getPendingActions,
   subscribeDiagnostics,
 } from "./diagnostics";
-
-/**
- * Invite link for the community Discord, used by the "share these logs"
- * prompt. Left empty until a real invite is configured — the prompt still
- * renders (and the copy button still works), just without a clickable link,
- * rather than shipping a URL that goes nowhere.
- */
-const DISCORD_INVITE_URL = "";
+import { DISCORD_INVITE_URL } from "../external-links";
 
 /** events that indicate something went wrong, highlighted in the list */
 const PROBLEM_EVENTS = new Set([
@@ -90,15 +83,10 @@ export function DiagnosticsDialog(props: {
     >
       <DialogBody>
         <Callout intent={Intent.PRIMARY} icon={<Clipboard />}>
-          {t("party.diagnostics.sharePrompt")}
-          {DISCORD_INVITE_URL ? (
-            <>
-              {" "}
-              <a href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer">
-                {t("party.diagnostics.openDiscord")}
-              </a>
-            </>
-          ) : null}
+          {t("party.diagnostics.sharePrompt")}{" "}
+          <a href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer">
+            {t("party.diagnostics.openDiscord")}
+          </a>
         </Callout>
 
         <h4 className={Classes.HEADING} style={{ marginTop: "1rem" }}>

--- a/src/party/diagnostics-dialog.tsx
+++ b/src/party/diagnostics-dialog.tsx
@@ -8,12 +8,13 @@ import {
   Intent,
   Tag,
 } from "@blueprintjs/core";
-import { Clipboard, Duplicate } from "@blueprintjs/icons";
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { Clipboard, Document, Duplicate } from "@blueprintjs/icons";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useIntl } from "../hooks/useIntl";
 import {
   formatAge,
   formatDiagnosticsReport,
+  formatFullDiagnosticsReport,
   formatTime,
   getDiagnostics,
   getPendingActions,
@@ -38,7 +39,8 @@ export function DiagnosticsDialog(props: {
 }) {
   const { t } = useIntl();
   const entries = useSyncExternalStore(subscribeDiagnostics, getDiagnostics);
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<"trimmed" | "full" | null>(null);
+  const fallbackRef = useRef<HTMLTextAreaElement>(null);
   // pending ages tick on their own, so re-render on a timer while open
   const [now, setNow] = useState(() => Date.now());
 
@@ -50,26 +52,30 @@ export function DiagnosticsDialog(props: {
 
   useEffect(() => {
     if (!copied) return;
-    const id = setTimeout(() => setCopied(false), 2500);
+    const id = setTimeout(() => setCopied(null), 2500);
     return () => clearTimeout(id);
   }, [copied]);
 
   const pending = getPendingActions();
 
-  async function copyReport() {
-    const report = formatDiagnosticsReport(props.roomName);
+  async function copyReport(kind: "trimmed" | "full") {
+    const report =
+      kind === "trimmed"
+        ? formatDiagnosticsReport(props.roomName)
+        : formatFullDiagnosticsReport(props.roomName);
     try {
       await navigator.clipboard.writeText(report);
-      setCopied(true);
+      setCopied(kind);
     } catch {
       // clipboard can be unavailable (insecure context, denied permission):
-      // fall back to selecting the text so the user can copy it by hand
-      const area = document.getElementById(
-        "party-diagnostics-report",
-      ) as HTMLTextAreaElement | null;
+      // fall back to selecting the text so the user can copy it by hand. The
+      // value is set imperatively because a state update wouldn't have landed
+      // by the time we select.
+      const area = fallbackRef.current;
       if (area) {
+        area.value = report;
         area.select();
-        setCopied(document.execCommand("copy"));
+        setCopied(document.execCommand("copy") ? kind : null);
       }
     }
   }
@@ -142,9 +148,10 @@ export function DiagnosticsDialog(props: {
 
         {/* offscreen copy target for browsers without the async clipboard */}
         <textarea
-          id="party-diagnostics-report"
-          readOnly
-          value={formatDiagnosticsReport(props.roomName)}
+          ref={fallbackRef}
+          aria-hidden
+          tabIndex={-1}
+          defaultValue=""
           style={{
             position: "absolute",
             left: "-9999px",
@@ -155,17 +162,30 @@ export function DiagnosticsDialog(props: {
       </DialogBody>
       <DialogFooter
         actions={
-          <Button
-            icon={<Duplicate />}
-            intent={copied ? Intent.SUCCESS : Intent.PRIMARY}
-            onClick={copyReport}
-            text={
-              copied
-                ? t("party.diagnostics.copied")
-                : t("party.diagnostics.copy")
-            }
-            data-umami-event="party-diagnostics-copy"
-          />
+          <>
+            <Button
+              icon={<Document />}
+              intent={copied === "full" ? Intent.SUCCESS : Intent.NONE}
+              onClick={() => copyReport("full")}
+              text={
+                copied === "full"
+                  ? t("party.diagnostics.copied")
+                  : t("party.diagnostics.copyFull")
+              }
+              data-umami-event="party-diagnostics-copy-full"
+            />
+            <Button
+              icon={<Duplicate />}
+              intent={copied === "trimmed" ? Intent.SUCCESS : Intent.PRIMARY}
+              onClick={() => copyReport("trimmed")}
+              text={
+                copied === "trimmed"
+                  ? t("party.diagnostics.copied")
+                  : t("party.diagnostics.copy")
+              }
+              data-umami-event="party-diagnostics-copy"
+            />
+          </>
         }
       />
     </Dialog>

--- a/src/party/diagnostics.ts
+++ b/src/party/diagnostics.ts
@@ -91,34 +91,65 @@ export function formatAge(since: number, now = Date.now()) {
   return `${Math.floor(seconds / 60)}m${pad(seconds % 60)}s`;
 }
 
+/** local UTC offset as "+02" / "-05:30", for reading timestamps back later */
+function utcOffset(d: Date) {
+  // getTimezoneOffset is minutes *behind* UTC, so the sign is inverted
+  const total = -d.getTimezoneOffset();
+  const sign = total < 0 ? "-" : "+";
+  const hours = pad(Math.floor(Math.abs(total) / 60));
+  const minutes = Math.abs(total) % 60;
+  return `${sign}${hours}${minutes ? `:${pad(minutes)}` : ""}`;
+}
+
 /**
- * The plain-text blob the copy button puts on the clipboard. Front-loads the
- * context we'd otherwise have to ask for (which room, when, which browser).
+ * A fenced block would end early if its own content contained a fence, so
+ * neutralise any backticks coming from a reducer's error message.
+ */
+function fenced(lines: string[]) {
+  return ["```", ...lines.map((l) => l.replaceAll("```", "'''")), "```"];
+}
+
+/**
+ * The blob the copy button puts on the clipboard. Front-loads the context we'd
+ * otherwise have to ask for (which room, when, which browser).
+ *
+ * Formatted as Discord-flavoured markdown, since the prompt next to the button
+ * asks people to paste it there: bold labels to make it skimmable, and fenced
+ * blocks for the two lists so they keep their column alignment and so action
+ * types and user-agent strings can't be eaten by markdown's own syntax.
  */
 export function formatDiagnosticsReport(roomName?: string): string {
   const now = new Date();
   const pending = getPendingActions();
-  const lines = [
-    "DDRCardDraw event connection diagnostics",
-    `room: ${roomName ?? "(unknown)"}`,
-    `generated: ${now.toISOString()} (local ${formatTime(now.getTime())}, UTC${
-      now.getTimezoneOffset() > 0 ? "-" : "+"
-    }${pad(Math.abs(now.getTimezoneOffset()) / 60)})`,
-    `user agent: ${
+  // pad the event column so details line up down the block
+  const eventWidth = entries.reduce((w, e) => Math.max(w, e.event.length), 0);
+
+  return [
+    "**DDRCardDraw event connection diagnostics**",
+    `**Room:** \`${roomName ?? "(unknown)"}\``,
+    `**Generated:** ${now.toISOString()} (local ${formatTime(now.getTime())}, UTC${utcOffset(now)})`,
+    `**Browser:** \`${
       typeof navigator === "undefined" ? "(unknown)" : navigator.userAgent
-    }`,
+    }\``,
     "",
-    `pending unsent changes: ${pending.length}`,
-    ...pending.map(
-      (p) =>
-        `  - ${p.type} (attempts: ${p.attempts}, waiting ${formatAge(p.since, now.getTime())})`,
-    ),
+    `**Changes not yet saved to the server:** ${pending.length}`,
+    ...(pending.length
+      ? fenced(
+          pending.map(
+            (p) =>
+              `${p.type} — waiting ${formatAge(p.since, now.getTime())}, ${p.attempts} attempt(s)`,
+          ),
+        )
+      : ["_none — the server confirmed every change_"]),
     "",
-    `log (${entries.length} event${entries.length === 1 ? "" : "s"}, oldest first):`,
-    ...entries.map(
-      (e) =>
-        `  ${formatTime(e.t)} ${e.event}${e.detail ? ` — ${e.detail}` : ""}`,
-    ),
-  ];
-  return lines.join("\n");
+    `**Connection log** (${entries.length} event${entries.length === 1 ? "" : "s"}, oldest first)`,
+    ...(entries.length
+      ? fenced(
+          entries.map(
+            (e) =>
+              `${formatTime(e.t)}  ${e.event.padEnd(eventWidth)}${e.detail ? `  ${e.detail}` : ""}`,
+          ),
+        )
+      : ["_nothing recorded_"]),
+  ].join("\n");
 }

--- a/src/party/diagnostics.ts
+++ b/src/party/diagnostics.ts
@@ -1,0 +1,124 @@
+/**
+ * A small in-memory log of what the party connection has been doing, kept so
+ * an organizer hitting connection trouble at an event can read it themselves
+ * and paste it to us without opening devtools.
+ *
+ * Like `connection-status.ts`, this lives outside redux on purpose: anything
+ * in the store is broadcast to the room and persisted server-side, and a
+ * per-client debug log is neither shared state nor something we want written
+ * into every event's snapshot.
+ */
+
+export interface DiagnosticEntry {
+  /** epoch ms */
+  t: number;
+  /** short label, e.g. "connected" / "action-rejected" */
+  event: string;
+  /** optional human-readable extra detail */
+  detail?: string;
+}
+
+/** one locally-dispatched action still waiting for the server to confirm it */
+export interface PendingActionInfo {
+  type: string;
+  attempts: number;
+  /** epoch ms of the first send attempt */
+  since: number;
+}
+
+/** plenty to cover an evening's worth of trouble without growing unbounded */
+const MAX_ENTRIES = 200;
+
+let entries: readonly DiagnosticEntry[] = [];
+const listeners = new Set<() => void>();
+let pendingProvider: (() => PendingActionInfo[]) | undefined;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+/** record one thing that happened on the party connection */
+export function logDiagnostic(event: string, detail?: string) {
+  // replace rather than mutate so useSyncExternalStore sees a new snapshot
+  const next = entries.concat({ t: Date.now(), event, detail });
+  entries = next.length > MAX_ENTRIES ? next.slice(-MAX_ENTRIES) : next;
+  emit();
+}
+
+export function getDiagnostics(): readonly DiagnosticEntry[] {
+  return entries;
+}
+
+export function subscribeDiagnostics(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * The sync manager owns the pending list, so it registers a getter here rather
+ * than us duplicating that state.
+ */
+export function setPendingActionsProvider(
+  provider: (() => PendingActionInfo[]) | undefined,
+) {
+  pendingProvider = provider;
+}
+
+export function getPendingActions(): PendingActionInfo[] {
+  return pendingProvider?.() ?? [];
+}
+
+export function clearDiagnostics() {
+  entries = [];
+  emit();
+}
+
+function pad(n: number) {
+  return String(n).padStart(2, "0");
+}
+
+/** local wall-clock time, which is what a user reading along will recognise */
+export function formatTime(t: number) {
+  const d = new Date(t);
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+export function formatAge(since: number, now = Date.now()) {
+  const seconds = Math.max(0, Math.round((now - since) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m${pad(seconds % 60)}s`;
+}
+
+/**
+ * The plain-text blob the copy button puts on the clipboard. Front-loads the
+ * context we'd otherwise have to ask for (which room, when, which browser).
+ */
+export function formatDiagnosticsReport(roomName?: string): string {
+  const now = new Date();
+  const pending = getPendingActions();
+  const lines = [
+    "DDRCardDraw event connection diagnostics",
+    `room: ${roomName ?? "(unknown)"}`,
+    `generated: ${now.toISOString()} (local ${formatTime(now.getTime())}, UTC${
+      now.getTimezoneOffset() > 0 ? "-" : "+"
+    }${pad(Math.abs(now.getTimezoneOffset()) / 60)})`,
+    `user agent: ${
+      typeof navigator === "undefined" ? "(unknown)" : navigator.userAgent
+    }`,
+    "",
+    `pending unsent changes: ${pending.length}`,
+    ...pending.map(
+      (p) =>
+        `  - ${p.type} (attempts: ${p.attempts}, waiting ${formatAge(p.since, now.getTime())})`,
+    ),
+    "",
+    `log (${entries.length} event${entries.length === 1 ? "" : "s"}, oldest first):`,
+    ...entries.map(
+      (e) =>
+        `  ${formatTime(e.t)} ${e.event}${e.detail ? ` — ${e.detail}` : ""}`,
+    ),
+  ];
+  return lines.join("\n");
+}

--- a/src/party/diagnostics.ts
+++ b/src/party/diagnostics.ts
@@ -110,46 +110,122 @@ function fenced(lines: string[]) {
 }
 
 /**
- * The blob the copy button puts on the clipboard. Front-loads the context we'd
- * otherwise have to ask for (which room, when, which browser).
- *
- * Formatted as Discord-flavoured markdown, since the prompt next to the button
- * asks people to paste it there: bold labels to make it skimmable, and fenced
- * blocks for the two lists so they keep their column alignment and so action
- * types and user-agent strings can't be eaten by markdown's own syntax.
+ * Discord rejects messages over 2000 characters (it offers to upload the paste
+ * as a file instead, which loses the formatting). The default report is
+ * trimmed to fit under that, keeping the most recent events, since the tail of
+ * a log is where the trouble is. `formatFullDiagnosticsReport` is the escape
+ * hatch when every event is wanted.
+ */
+const DISCORD_MESSAGE_LIMIT = 2000;
+/** a little headroom, so a report that just fits isn't right on the edge */
+const MARKDOWN_BUDGET = DISCORD_MESSAGE_LIMIT - 100;
+
+function reportBody(
+  roomName: string | undefined,
+  now: Date,
+  pending: PendingActionInfo[],
+  shown: readonly DiagnosticEntry[],
+  total: number,
+  md: boolean,
+): string {
+  const code = (s: string) => (md ? `\`${s}\`` : s);
+  const label = (l: string, v: string) =>
+    md ? `**${l}:** ${v}` : `${l}: ${v}`;
+  const block = (body: string[]) =>
+    md ? fenced(body) : body.map((l) => `  ${l}`);
+  const none = (s: string) => (md ? `_${s}_` : `  ${s}`);
+
+  const pendingBody = pending.map(
+    (p) =>
+      `${p.type} — waiting ${formatAge(p.since, now.getTime())}, ${p.attempts} attempt(s)`,
+  );
+
+  // pad the event column so details line up down the block
+  const width = shown.reduce((w, e) => Math.max(w, e.event.length), 0);
+  const logBody = shown.map(
+    (e) =>
+      `${formatTime(e.t)}  ${e.event.padEnd(width)}${e.detail ? `  ${e.detail}` : ""}`,
+  );
+
+  const omitted = total - shown.length;
+  const logCount = omitted
+    ? `most recent ${shown.length} of ${total} events`
+    : `${total} event${total === 1 ? "" : "s"}`;
+
+  return [
+    md
+      ? "**DDRCardDraw event connection diagnostics**"
+      : "DDRCardDraw event connection diagnostics",
+    label("Room", code(roomName ?? "(unknown)")),
+    label(
+      "Generated",
+      `${now.toISOString()} (local ${formatTime(now.getTime())}, UTC${utcOffset(now)})`,
+    ),
+    label(
+      "Browser",
+      code(
+        typeof navigator === "undefined" ? "(unknown)" : navigator.userAgent,
+      ),
+    ),
+    "",
+    label("Changes not yet saved to the server", String(pending.length)),
+    ...(pending.length
+      ? block(pendingBody)
+      : [none("none — the server confirmed every change")]),
+    "",
+    md
+      ? `**Connection log** (${logCount}, oldest first)`
+      : `Connection log (${logCount}, oldest first)`,
+    ...(shown.length ? block(logBody) : [none("nothing recorded")]),
+    ...(omitted
+      ? [
+          none(
+            `${omitted} earlier event${omitted === 1 ? "" : "s"} trimmed to fit — ask for the full log if needed`,
+          ),
+        ]
+      : []),
+  ].join("\n");
+}
+
+/**
+ * The report the main copy button puts on the clipboard: Discord-flavoured
+ * markdown, trimmed to fit in one message. Bold labels make it skimmable, and
+ * the two lists sit in fenced blocks so they keep their column alignment and
+ * so action types and user-agent strings can't be eaten by markdown's own
+ * syntax.
  */
 export function formatDiagnosticsReport(roomName?: string): string {
   const now = new Date();
   const pending = getPendingActions();
-  // pad the event column so details line up down the block
-  const eventWidth = entries.reduce((w, e) => Math.max(w, e.event.length), 0);
+  const total = entries.length;
+  // include as many of the most recent events as fit; if even one event puts
+  // us over (a huge pending list, say), keep it rather than emitting no log
+  for (let take = total; take > 1; take--) {
+    const text = reportBody(
+      roomName,
+      now,
+      pending,
+      entries.slice(total - take),
+      total,
+      true,
+    );
+    if (text.length <= MARKDOWN_BUDGET) return text;
+  }
+  return reportBody(roomName, now, pending, entries.slice(-1), total, true);
+}
 
-  return [
-    "**DDRCardDraw event connection diagnostics**",
-    `**Room:** \`${roomName ?? "(unknown)"}\``,
-    `**Generated:** ${now.toISOString()} (local ${formatTime(now.getTime())}, UTC${utcOffset(now)})`,
-    `**Browser:** \`${
-      typeof navigator === "undefined" ? "(unknown)" : navigator.userAgent
-    }\``,
-    "",
-    `**Changes not yet saved to the server:** ${pending.length}`,
-    ...(pending.length
-      ? fenced(
-          pending.map(
-            (p) =>
-              `${p.type} — waiting ${formatAge(p.since, now.getTime())}, ${p.attempts} attempt(s)`,
-          ),
-        )
-      : ["_none — the server confirmed every change_"]),
-    "",
-    `**Connection log** (${entries.length} event${entries.length === 1 ? "" : "s"}, oldest first)`,
-    ...(entries.length
-      ? fenced(
-          entries.map(
-            (e) =>
-              `${formatTime(e.t)}  ${e.event.padEnd(eventWidth)}${e.detail ? `  ${e.detail}` : ""}`,
-          ),
-        )
-      : ["_nothing recorded_"]),
-  ].join("\n");
+/**
+ * Every recorded event, as plain text. For when the trimmed report isn't
+ * enough and a maintainer asks for the lot — it is expected to arrive as a
+ * file attachment, where markdown decoration would just be noise.
+ */
+export function formatFullDiagnosticsReport(roomName?: string): string {
+  return reportBody(
+    roomName,
+    new Date(),
+    getPendingActions(),
+    entries,
+    entries.length,
+    false,
+  );
 }

--- a/src/party/server.ts
+++ b/src/party/server.ts
@@ -53,6 +53,29 @@ interface SyncMeta {
   seenIds: string[];
 }
 
+/**
+ * greppable prefix shared by every diagnostic line this server emits. Filter
+ * production logs with this to trace a room's persisted-snapshot lifecycle.
+ */
+const LOG_PREFIX = "[party-diag]";
+
+/**
+ * Cheap, side-effect-free fingerprint of the shared state so log lines can be
+ * compared across events to see whether the persisted snapshot advanced. Uses
+ * the drawings entity count plus the serialized length as a poor-man's hash;
+ * this is for observability only and never feeds back into state.
+ */
+function stateFingerprint(state: AppState): string {
+  const drawings = state.drawings?.ids?.length ?? 0;
+  let stateLen = -1;
+  try {
+    stateLen = JSON.stringify(state).length;
+  } catch {
+    stateLen = -1;
+  }
+  return `drawings=${drawings} stateLen=${stateLen}`;
+}
+
 export default class Server implements Party.Server {
   // @ts-expect-error I assign this for sure
   private store: typeof appReduxStore;
@@ -76,13 +99,41 @@ export default class Server implements Party.Server {
     console.log("constructor start");
   }
 
+  /** emit a single greppable diagnostic line tagged with this room's id */
+  private log(event: string, details = "") {
+    console.log(
+      `${LOG_PREFIX} room=${this.room.id} ${event}${details ? ` ${details}` : ""}`,
+    );
+  }
+
+  /** current count of live connections, for correlating socket cycles */
+  private connectionCount(): number {
+    return [...this.room.getConnections()].length;
+  }
+
   async onStart() {
     let preloadedState: AppState | undefined;
+    let source = "fresh";
     try {
-      preloadedState =
-        (await this.getFromStorage()) || (await this.getFromSupabase());
+      // preserve the original `storage || supabase` short-circuit: supabase is
+      // only consulted when storage came back empty. Split apart only so the
+      // hydration source can be logged.
+      const fromStorage = await this.getFromStorage();
+      const fromSupabase = fromStorage
+        ? undefined
+        : await this.getFromSupabase();
+      preloadedState = fromStorage || fromSupabase;
+      if (fromStorage) source = "storage";
+      else if (fromSupabase) source = "supabase";
       if (preloadedState) applyMigrations(preloadedState);
-    } catch {}
+    } catch (e) {
+      // previously swallowed silently; surface it since a failed hydrate is a
+      // prime suspect for reverting a room to a stale checkpoint.
+      console.error(
+        `${LOG_PREFIX} room=${this.room.id} onStart:hydrate-error`,
+        e,
+      );
+    }
     if (preloadedState) {
       this.store = configureStore({ reducer, preloadedState });
     } else {
@@ -91,13 +142,27 @@ export default class Server implements Party.Server {
     // restore the sequencer counter + dedupe set so a hibernated/restarted
     // room doesn't reset seq to 0 or forget which ids it already applied
     // (which would let a client's re-send be applied a second time)
+    let metaSource = "none";
     try {
       const meta = await this.room.storage.get<SyncMeta>(SYNC_META_KEY);
       if (meta) {
         this.seq = meta.seq;
         this.seenActionIds = new Map(meta.seenIds.map((id) => [id, meta.seq]));
+        metaSource = "storage";
       }
-    } catch {}
+    } catch (e) {
+      metaSource = "error";
+      console.error(
+        `${LOG_PREFIX} room=${this.room.id} onStart:syncMeta-error`,
+        e,
+      );
+    }
+    // logged after the sequencer restore so `seq` reflects the resumed value
+    // rather than a misleading 0
+    this.log(
+      "onStart",
+      `source=${source} syncMeta=${metaSource} seq=${this.seq} ${stateFingerprint(this.store.getState())}`,
+    );
   }
 
   private async getFromSupabase() {
@@ -136,6 +201,12 @@ export default class Server implements Party.Server {
   id: ${conn.id}
   room: ${this.room.id}
   url: ${new URL(ctx.request.url).pathname}`,
+    );
+
+    const servedState = this.store.getState();
+    this.log(
+      "onConnect",
+      `conn=${conn.id} connections=${this.connectionCount()} serving roomstate seq=${this.seq} ${stateFingerprint(servedState)}`,
     );
 
     // send the initial state to this client
@@ -186,8 +257,8 @@ export default class Server implements Party.Server {
       this.store.dispatch(parsed.action);
     } catch (e) {
       const reason = e instanceof Error ? e.message : String(e);
-      console.warn(
-        `rejecting action ${parsed.action?.type} in room ${this.room.id}:`,
+      console.error(
+        `${LOG_PREFIX} room=${this.room.id} action:rejected type=${parsed.action?.type} id=${parsed.id ?? "none"} seq=${this.seq}`,
         e,
       );
       // seq is not consumed, the id is not remembered, nothing is broadcast:
@@ -216,27 +287,69 @@ export default class Server implements Party.Server {
     }
 
     const nextState = this.store.getState();
+    const fingerprint = stateFingerprint(nextState);
+    this.log(
+      "handleAction",
+      `type=${parsed.action?.type} id=${parsed.id ?? "none"} seq=${parsed.id ? this.seq : "n/a"} ${fingerprint}`,
+    );
+
     // persist to partykit storage: the state itself, plus the sequencer
-    // metadata so dedupe/ordering survive a hibernation or restart
-    void this.room.storage.put("currentState", nextState);
+    // metadata so dedupe/ordering survive a hibernation or restart. Both stay
+    // fire-and-forget (unchanged behavior); wrapped only so we can observe
+    // whether the write actually resolves before the room is evicted, or
+    // rejects.
+    this.log("storage.put:start", fingerprint);
+    void this.room.storage
+      .put("currentState", nextState)
+      .then(() => this.log("storage.put:ok", fingerprint))
+      .catch((e: unknown) =>
+        console.error(
+          `${LOG_PREFIX} room=${this.room.id} storage.put:error ${fingerprint}`,
+          e,
+        ),
+      );
+
     if (parsed.id) {
-      void this.room.storage.put<SyncMeta>(SYNC_META_KEY, {
-        seq: this.seq,
-        seenIds: Array.from(this.seenActionIds.keys()),
-      });
+      void this.room.storage
+        .put<SyncMeta>(SYNC_META_KEY, {
+          seq: this.seq,
+          seenIds: Array.from(this.seenActionIds.keys()),
+        })
+        .then(() => this.log("syncMeta.put:ok", `seq=${this.seq}`))
+        .catch((e: unknown) =>
+          console.error(
+            `${LOG_PREFIX} room=${this.room.id} syncMeta.put:error seq=${this.seq}`,
+            e,
+          ),
+        );
     }
 
     // persist the state to supabase
     try {
       if (supabase) {
-        await supabase.from("event_state").upsert({
+        // supabase returns errors in the result rather than throwing, so the
+        // existing catch never saw them: capture and log the returned error
+        // loudly, since a swallowed upsert failure would leave the served
+        // snapshot stale on the next reconnect.
+        const { error } = await supabase.from("event_state").upsert({
           id: this.room.id,
           state: nextState as unknown as Json,
           updated_at: new Date().toISOString(),
         });
+        if (error) {
+          console.error(
+            `${LOG_PREFIX} room=${this.room.id} supabase.upsert:error ${fingerprint}`,
+            error,
+          );
+        } else {
+          this.log("supabase.upsert:ok", fingerprint);
+        }
       }
     } catch (e) {
-      console.warn("error with upsert", e);
+      console.error(
+        `${LOG_PREFIX} room=${this.room.id} supabase.upsert:throw ${fingerprint}`,
+        e,
+      );
     }
   }
 
@@ -248,6 +361,10 @@ export default class Server implements Party.Server {
   private handleCatchup(req: CatchupRequest, sender: Party.Connection) {
     if (req.since >= this.seq) {
       // client is already current (or ahead); nothing to replay
+      this.log(
+        "catchup",
+        `conn=${sender.id} since=${req.since} result=current`,
+      );
       sender.send(
         JSON.stringify(<CatchupResponse>{ type: "catchup", actions: [] }),
       );
@@ -256,11 +373,19 @@ export default class Server implements Party.Server {
     const earliest = this.tail.length ? this.tail[0].seq : Infinity;
     if (req.since >= earliest - 1) {
       const actions = this.tail.filter((a) => a.seq > req.since);
+      this.log(
+        "catchup",
+        `conn=${sender.id} since=${req.since} result=replay actions=${actions.length} seq=${this.seq}`,
+      );
       sender.send(
         JSON.stringify(<CatchupResponse>{ type: "catchup", actions }),
       );
     } else {
       // the gap predates our tail; only a fresh snapshot can repair the client
+      this.log(
+        "catchup",
+        `conn=${sender.id} since=${req.since} result=full-roomstate earliest=${earliest} seq=${this.seq}`,
+      );
       sender.send(JSON.stringify(this.roomstateMessage()));
     }
   }
@@ -272,6 +397,22 @@ export default class Server implements Party.Server {
       recentActionIds: Array.from(this.seenActionIds.keys()),
       seq: this.seq,
     };
+  }
+
+  onClose(conn: Party.Connection) {
+    // correlate socket cycles (flaky venue wifi) and potential hibernation with
+    // whichever snapshot was last served/persisted for this room.
+    this.log(
+      "onClose",
+      `conn=${conn.id} connections=${this.connectionCount()} seq=${this.seq} ${stateFingerprint(this.store.getState())}`,
+    );
+  }
+
+  onError(conn: Party.Connection, err: Error) {
+    console.error(
+      `${LOG_PREFIX} room=${this.room.id} onError conn=${conn.id} seq=${this.seq}`,
+      err,
+    );
   }
 
   private sendAck(conn: Party.Connection, id: string) {

--- a/src/party/server.ts
+++ b/src/party/server.ts
@@ -60,12 +60,12 @@ interface SyncMeta {
 const LOG_PREFIX = "[party-diag]";
 
 /**
- * Cheap, side-effect-free fingerprint of the shared state so log lines can be
- * compared across events to see whether the persisted snapshot advanced. Uses
- * the drawings entity count plus the serialized length as a poor-man's hash;
- * this is for observability only and never feeds back into state.
+ * Cheap, side-effect-free fingerprint of the shared state so snapshots can be
+ * compared to see whether the persisted state advanced. Uses the drawings
+ * entity count plus the serialized length as a poor-man's hash; this is for
+ * observability only and never feeds back into state.
  */
-function stateFingerprint(state: AppState): string {
+function fingerprintParts(state: AppState) {
   const drawings = state.drawings?.ids?.length ?? 0;
   let stateLen = -1;
   try {
@@ -73,8 +73,39 @@ function stateFingerprint(state: AppState): string {
   } catch {
     stateLen = -1;
   }
-  return `drawings=${drawings} stateLen=${stateLen}`;
+  return { drawings, stateLen };
 }
+
+function formatFingerprint(parts: { drawings: number; stateLen: number }) {
+  return `drawings=${parts.drawings} stateLen=${parts.stateLen}`;
+}
+
+function stateFingerprint(state: AppState): string {
+  return formatFingerprint(fingerprintParts(state));
+}
+
+/** shape of the `?debug` snapshot for one persistence target */
+interface SnapshotInfo {
+  present: boolean;
+  fingerprint?: string;
+  drawings?: number;
+  stateLen?: number;
+  updatedAt?: string;
+  matchesMemory?: boolean;
+  error?: string;
+}
+
+function describeError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === "string") return e;
+  try {
+    return JSON.stringify(e);
+  } catch {
+    return String(e);
+  }
+}
+
+const CORS_HEADERS = { "Access-Control-Allow-Origin": "*" };
 
 export default class Server implements Party.Server {
   // @ts-expect-error I assign this for sure
@@ -95,6 +126,48 @@ export default class Server implements Party.Server {
    */
   private tail: StampedAction[] = [];
 
+  // ---- diagnostics, reported by `GET ...?debug`. In-memory only: they
+  // describe the *current* room instance and reset when it is evicted.
+
+  private instanceStartedAt = Date.now();
+
+  /** how this instance's state was hydrated at startup */
+  private hydration: {
+    source: "storage" | "supabase" | "fresh";
+    at: string;
+    fingerprint: string | null;
+    error: string | null;
+  } | null = null;
+
+  /** tallies for the fire-and-forget `currentState` writes */
+  private storageWrites = {
+    started: 0,
+    ok: 0,
+    failed: 0,
+    lastOkAt: null as string | null,
+    lastErrorAt: null as string | null,
+  };
+
+  private supabaseWrites = {
+    ok: 0,
+    failed: 0,
+    lastOkAt: null as string | null,
+    lastErrorAt: null as string | null,
+  };
+
+  private lastAction: { type: string; seq: number; at: string } | null = null;
+
+  private lastError: { at: string; where: string; message: string } | null =
+    null;
+
+  private recordError(where: string, e: unknown) {
+    this.lastError = {
+      at: new Date().toISOString(),
+      where,
+      message: describeError(e),
+    };
+  }
+
   constructor(readonly room: Party.Room) {
     console.log("constructor start");
   }
@@ -113,7 +186,8 @@ export default class Server implements Party.Server {
 
   async onStart() {
     let preloadedState: AppState | undefined;
-    let source = "fresh";
+    let source: "storage" | "supabase" | "fresh" = "fresh";
+    let hydrateError: string | null = null;
     try {
       // preserve the original `storage || supabase` short-circuit: supabase is
       // only consulted when storage came back empty. Split apart only so the
@@ -129,6 +203,8 @@ export default class Server implements Party.Server {
     } catch (e) {
       // previously swallowed silently; surface it since a failed hydrate is a
       // prime suspect for reverting a room to a stale checkpoint.
+      hydrateError = describeError(e);
+      this.recordError("onStart", e);
       console.error(
         `${LOG_PREFIX} room=${this.room.id} onStart:hydrate-error`,
         e,
@@ -157,11 +233,18 @@ export default class Server implements Party.Server {
         e,
       );
     }
+    const fingerprint = stateFingerprint(this.store.getState());
+    this.hydration = {
+      source,
+      at: new Date().toISOString(),
+      fingerprint,
+      error: hydrateError,
+    };
     // logged after the sequencer restore so `seq` reflects the resumed value
     // rather than a misleading 0
     this.log(
       "onStart",
-      `source=${source} syncMeta=${metaSource} seq=${this.seq} ${stateFingerprint(this.store.getState())}`,
+      `source=${source} syncMeta=${metaSource} seq=${this.seq} ${fingerprint}`,
     );
   }
 
@@ -184,14 +267,157 @@ export default class Server implements Party.Server {
 
   onRequest(req: Party.Request): Response | Promise<Response> {
     if (req.method === "GET") {
+      // opt-in health snapshot: `?debug` reports how this room instance
+      // hydrated and whether its writes are landing, without changing the
+      // default response clients rely on.
+      if (new URL(req.url).searchParams.has("debug")) {
+        return this.debugResponse();
+      }
       return Response.json(this.store.getState(), {
-        headers: {
-          "Access-Control-Allow-Origin": "*",
-        },
+        headers: CORS_HEADERS,
       });
     }
 
     return new Response("Method not allowed", { status: 405 });
+  }
+
+  /**
+   * Compare the in-memory state against both persistence targets so a single
+   * request answers "did this room's persisted snapshot stop advancing?".
+   *
+   * Caveat: requesting this instantiates the room if it was evicted, so the
+   * counters describe the instance you just woke, not the one that died. The
+   * durable comparison below is what survives an eviction.
+   */
+  private async debugResponse(): Promise<Response> {
+    const memoryState = this.store.getState();
+    const memory = fingerprintParts(memoryState);
+    const memoryFingerprint = formatFingerprint(memory);
+
+    const [storage, supabaseSnapshot] = await Promise.all([
+      this.describeStorage(memoryFingerprint),
+      this.describeSupabase(memoryFingerprint),
+    ]);
+
+    const unsettled =
+      this.storageWrites.started -
+      this.storageWrites.ok -
+      this.storageWrites.failed;
+
+    const warnings: string[] = [];
+    if (unsettled > 0) {
+      warnings.push(
+        `${unsettled} storage write(s) started but never settled — they may not flush before eviction`,
+      );
+    }
+    if (storage.present && storage.matchesMemory === false) {
+      warnings.push(
+        "persisted storage snapshot differs from in-memory state — the durable write is not keeping up",
+      );
+    }
+    if (!storage.present && this.lastAction) {
+      warnings.push(
+        "no currentState in storage despite actions having been applied",
+      );
+    }
+    if (
+      storage.present &&
+      supabaseSnapshot.present &&
+      storage.fingerprint !== supabaseSnapshot.fingerprint
+    ) {
+      warnings.push(
+        "storage and supabase disagree — onStart prefers storage, so a stale storage value pins this room to an old checkpoint",
+      );
+    }
+    if (this.storageWrites.failed > 0) {
+      warnings.push(`${this.storageWrites.failed} storage write(s) failed`);
+    }
+    if (this.supabaseWrites.failed > 0) {
+      warnings.push(`${this.supabaseWrites.failed} supabase upsert(s) failed`);
+    }
+    if (this.hydration?.error) {
+      warnings.push(`hydration errored: ${this.hydration.error}`);
+    }
+
+    return Response.json(
+      {
+        room: this.room.id,
+        now: new Date().toISOString(),
+        instance: {
+          startedAt: new Date(this.instanceStartedAt).toISOString(),
+          uptimeMs: Date.now() - this.instanceStartedAt,
+        },
+        seq: this.seq,
+        connections: this.connectionCount(),
+        rememberedActionIds: this.seenActionIds.size,
+        memory: { ...memory, fingerprint: memoryFingerprint },
+        storage,
+        supabase: supabaseSnapshot,
+        hydration: this.hydration,
+        writes: {
+          storage: { ...this.storageWrites, unsettled },
+          supabase: { ...this.supabaseWrites, enabled: !!supabase },
+        },
+        lastAction: this.lastAction,
+        lastError: this.lastError,
+        healthy: warnings.length === 0,
+        warnings,
+      },
+      { headers: CORS_HEADERS },
+    );
+  }
+
+  /** read back what is actually durable in room storage right now */
+  private async describeStorage(
+    memoryFingerprint: string,
+  ): Promise<SnapshotInfo> {
+    try {
+      const stored = await this.getFromStorage();
+      if (!stored) return { present: false };
+      const parts = fingerprintParts(stored);
+      const fingerprint = formatFingerprint(parts);
+      return {
+        present: true,
+        ...parts,
+        fingerprint,
+        matchesMemory: fingerprint === memoryFingerprint,
+      };
+    } catch (e) {
+      return { present: false, error: describeError(e) };
+    }
+  }
+
+  private async describeSupabase(
+    memoryFingerprint: string,
+  ): Promise<SnapshotInfo> {
+    if (!supabase) return { present: false, error: "supabase not configured" };
+    try {
+      const { data, error } = await supabase
+        .from("event_state")
+        .select("state, updated_at")
+        .eq("id", this.room.id)
+        .maybeSingle();
+      if (error) return { present: false, error: error.message };
+      if (!data) return { present: false };
+      if (!isAppState(data.state)) {
+        return {
+          present: true,
+          updatedAt: data.updated_at,
+          error: "stored row is not a recognizable AppState",
+        };
+      }
+      const parts = fingerprintParts(data.state);
+      const fingerprint = formatFingerprint(parts);
+      return {
+        present: true,
+        ...parts,
+        fingerprint,
+        updatedAt: data.updated_at,
+        matchesMemory: fingerprint === memoryFingerprint,
+      };
+    } catch (e) {
+      return { present: false, error: describeError(e) };
+    }
   }
 
   onConnect(conn: Party.Connection, ctx: Party.ConnectionContext) {
@@ -288,6 +514,11 @@ export default class Server implements Party.Server {
 
     const nextState = this.store.getState();
     const fingerprint = stateFingerprint(nextState);
+    this.lastAction = {
+      type: String(parsed.action?.type),
+      seq: this.seq,
+      at: new Date().toISOString(),
+    };
     this.log(
       "handleAction",
       `type=${parsed.action?.type} id=${parsed.id ?? "none"} seq=${parsed.id ? this.seq : "n/a"} ${fingerprint}`,
@@ -298,16 +529,24 @@ export default class Server implements Party.Server {
     // fire-and-forget (unchanged behavior); wrapped only so we can observe
     // whether the write actually resolves before the room is evicted, or
     // rejects.
+    this.storageWrites.started += 1;
     this.log("storage.put:start", fingerprint);
     void this.room.storage
       .put("currentState", nextState)
-      .then(() => this.log("storage.put:ok", fingerprint))
-      .catch((e: unknown) =>
+      .then(() => {
+        this.storageWrites.ok += 1;
+        this.storageWrites.lastOkAt = new Date().toISOString();
+        this.log("storage.put:ok", fingerprint);
+      })
+      .catch((e: unknown) => {
+        this.storageWrites.failed += 1;
+        this.storageWrites.lastErrorAt = new Date().toISOString();
+        this.recordError("storage.put", e);
         console.error(
           `${LOG_PREFIX} room=${this.room.id} storage.put:error ${fingerprint}`,
           e,
-        ),
-      );
+        );
+      });
 
     if (parsed.id) {
       void this.room.storage
@@ -337,15 +576,23 @@ export default class Server implements Party.Server {
           updated_at: new Date().toISOString(),
         });
         if (error) {
+          this.supabaseWrites.failed += 1;
+          this.supabaseWrites.lastErrorAt = new Date().toISOString();
+          this.recordError("supabase.upsert", error);
           console.error(
             `${LOG_PREFIX} room=${this.room.id} supabase.upsert:error ${fingerprint}`,
             error,
           );
         } else {
+          this.supabaseWrites.ok += 1;
+          this.supabaseWrites.lastOkAt = new Date().toISOString();
           this.log("supabase.upsert:ok", fingerprint);
         }
       }
     } catch (e) {
+      this.supabaseWrites.failed += 1;
+      this.supabaseWrites.lastErrorAt = new Date().toISOString();
+      this.recordError("supabase.upsert", e);
       console.error(
         `${LOG_PREFIX} room=${this.room.id} supabase.upsert:throw ${fingerprint}`,
         e,

--- a/src/party/sync-manager.ts
+++ b/src/party/sync-manager.ts
@@ -3,6 +3,7 @@ import type { Action } from "@reduxjs/toolkit";
 import { reducer } from "../state/root-reducer";
 import type { AppState } from "../state/store";
 import type { ReduxAction, Roomstate, StampedAction } from "./types";
+import type { PendingActionInfo } from "./diagnostics";
 
 /** how long to wait for the server to confirm receipt before re-sending */
 const ACK_TIMEOUT_MS = 5000;
@@ -23,6 +24,8 @@ interface PendingEntry {
   message: ReduxAction & { id: string };
   attempts: number;
   timer?: ReturnType<typeof setTimeout>;
+  /** epoch ms of the first send attempt, for the diagnostics panel */
+  since: number;
 }
 
 /**
@@ -82,6 +85,7 @@ export class SyncManager {
     const entry: PendingEntry = {
       message: { type: "action", action, id: nanoid() },
       attempts: 0,
+      since: Date.now(),
     };
     this.pending.set(entry.message.id, entry);
     this.transmit(entry);
@@ -176,6 +180,15 @@ export class SyncManager {
   /** count of actions awaiting confirmation */
   get pendingCount() {
     return this.pending.size;
+  }
+
+  /** what is still unconfirmed, for the user-facing diagnostics panel */
+  get pendingActions(): PendingActionInfo[] {
+    return Array.from(this.pending.values(), (entry) => ({
+      type: String(entry.message.action.type),
+      attempts: entry.attempts,
+      since: entry.since,
+    }));
   }
 
   dispose() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5478,14 +5478,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"canvas@npm:3.2.0":
-  version: 3.2.0
-  resolution: "canvas@npm:3.2.0"
+"canvas@npm:3.2.3":
+  version: 3.2.3
+  resolution: "canvas@npm:3.2.3"
   dependencies:
     node-addon-api: "npm:^7.0.0"
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.3"
-  checksum: 10/d1506b28dce31cb2292c92e827acb41eb6360ebf382d41dffffd056543aa49f083cae44886586a5ce9c5dc3f107f1938750a23381556dd3b6eeffdc0dfd7cdd8
+  checksum: 10/88e3a30f0a9afbb74377111effaeeb3bbe05ea7387801840d25fd514afb706d5a10c30ddf93cf5be64044712559a4e6b4427d8d3557ba72259c29200adb7f348
   languageName: node
   linkType: hard
 
@@ -6541,7 +6541,7 @@ __metadata:
     babel-loader: "npm:10.0.0"
     better-sqlite3: "npm:12.5.0"
     cacheable-lookup: "npm:7.0.0"
-    canvas: "npm:3.2.0"
+    canvas: "npm:3.2.3"
     classnames: "npm:2.5.1"
     clean-webpack-plugin: "npm:4.0.0"
     copy-webpack-plugin: "npm:13.0.1"


### PR DESCRIPTION
Tooling to find out **where an event room's persisted snapshot stops advancing**. This is diagnosis only — no fix for the underlying bug, and no change to how state is stored or served.

## The bug being chased

Two clients in one event room. An edit shows up on the other machine, but after a socket cycle (flaky venue wifi) both reset to an earlier state and keep snapping back to that same checkpoint. The suspicion is that edits reach peers via broadcast but aren't durably stored, so the next reconnect's `roomstate` reverts everyone.

Two suspects, both addressed here:

1. The fire-and-forget `void this.room.storage.put("currentState", ...)` may not flush before the room is evicted or hibernated.
2. Supabase upserts may be failing silently — supabase returns errors in the result rather than throwing, so the existing `try/catch` never saw them.

Since `onStart` is `getFromStorage() || getFromSupabase()`, a stale-but-present storage value **always beats a fresher Supabase row** — Supabase is never even consulted. That would pin a room to one checkpoint indefinitely, which matches "keep snapping back to that same checkpoint" better than a one-off lost write (which would self-heal on the next action).

## What's in here

### 1. Diagnostic logging (`src/party/server.ts`) — no behavior change

Structured, greppable lines (prefix `[party-diag]`, one per event, `room=<id>` on every line) at `onStart` (hydration source + fingerprint + seq), `onConnect` (roomstate served + connection count), `handleAction` (type, seq, post-dispatch fingerprint), around the storage write, around the supabase upsert, and `onClose`/`onError`.

The state fingerprint is `drawings=<count> stateLen=<JSON length>` — cheap, and comparable across events to see whether the snapshot advanced.

Deliberately **not** changed: the storage put stays fire-and-forget (wrapped with `.then`/`.catch` for observability, not awaited, so timing is untouched), and the `storage || supabase` short-circuit is preserved. Two previously-swallowed errors now log loudly: the empty `catch {}` in `onStart`, and the supabase upsert's returned `error`.

### 2. `scripts/watch-room.mjs` / `yarn watch:room`

`partykit tail` accepts a server-side `--search` filter, and every diagnostic line carries `room=<id>`, so the firehose can be narrowed to one event. The room id is the `:roomName` from the event URL, so a reporter's link pastes in verbatim:

```
yarn watch:room https://ddrdraw.surge.sh/#/e/abc123
```

It digests the stream into a timeline and flags the two signatures that matter: a room restarting while holding unsettled storage writes, and an `onStart` hydrating a snapshot that doesn't match the last state an action produced.

Because the server-side search matches whole invocations and isn't anchored, it re-filters client-side on an exact `room=` match.

Tail sessions expire and the CLI doesn't reconnect, so the tail is supervised and restarted with backoff (giving up after 5 failures that never stay up). Tail has **no backfill**, so gaps are printed rather than papered over, and findings that straddle one are handled honestly: in-flight writes move to an "outcome unknown" tally instead of being reported as lost, and baseline-dependent alerts are marked uncertain until a fresh action re-establishes the baseline. `--out <file>` appends a colour-free copy so it can be parked for a whole event.

### 3. Opt-in `?debug` health snapshot

Hosted PartyKit has no persistent logs — `partykit tail` is live-only, and the `logpush`/`tailConsumers`/`analytics` config keys all require your own `CLOUDFLARE_ACCOUNT_ID` + token, which a `*.partykit.dev` deploy doesn't have. So a report arriving hours later needs the room to describe its own health on demand:

```
GET /parties/main/<room>?debug
```

returns three views of the same state side by side — `memory`, `storage` (read back, with `matchesMemory`), and `supabase` (with `updated_at` and `matchesMemory`) — plus hydration source, storage/supabase write tallies (`started`/`ok`/`failed`/`unsettled`), last action, last error, and connection count. A `healthy` boolean and `warnings` array make it self-interpreting; it explicitly calls out storage and supabase disagreeing.

**The default `GET` response is untouched** — the debug branch is gated on the query param, so `getPartykitState()` is unaffected. Note this is the one behavior change in the PR (additive and opt-in).

## Verification

`tsc --noemit`, `oxlint`, and `oxfmt --check` all pass.

The endpoint was exercised against a real local `partykit dev`, not just typechecked:

- Plain `GET` still returns raw `AppState`, unchanged.
- After driving two actions over a live websocket: `seq=2`, `storage.matchesMemory: true`, `2 started / 2 ok / 0 unsettled`, `healthy: true`, with `memory` visibly ahead of `hydration`.
- With a **deliberately stalled storage write** injected, it reproduced the production shape and caught it: `memory=346` vs `storage=291`, `unsettled: 1`, `healthy: false`, with both expected warnings. The injection was reverted and the committed code re-verified healthy.

The watcher was run against synthetic tail streams covering the bug shape, a healthy room, the error/exception paths, and a mid-stream tail drop. Alerts fire only where warranted — notably the bug-shape alerts appear unqualified without a gap and qualified with one — and a healthy room produces no alerts at all.

## Known limitations

- `?debug` **instantiates the room if it was evicted**, so the counters describe the instance you just woke, not the one that died. The storage-vs-supabase comparison is the part that survives an eviction — and that's the part that localizes this bug.
- `seq` is in-memory only and resets to `0` on every `onStart`, so it is not a progress marker across restarts; the fingerprint is. (That reset may itself be worth a look later.)
- Logs during a watcher reconnect gap are unrecoverable — hence the explicit gap markers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmuaLNBXFwzHU6BUd1vGtD)_