### PR TITLE
Add button to delete text sources

### DIFF
--- a/src/tournament-mode/dashboard.tsx
+++ b/src/tournament-mode/dashboard.tsx
@@ -13,7 +13,7 @@ import {
   InputGroup,
 } from "@blueprintjs/core";
 import { useAppDispatch, useAppState } from "../state/store";
-import { Add, Duplicate, Edit, FloppyDisk } from "@blueprintjs/icons";
+import { Add, Duplicate, Edit, FloppyDisk, Trash } from "@blueprintjs/icons";
 import React, { useRef, useState } from "react";
 import { eventSlice } from "../state/event.slice";
 import { nanoid } from "nanoid";
@@ -28,6 +28,7 @@ export function Dashboard() {
   const [currentEdit, setCurrentEdit] = useState<string | null>(null);
   const labels = useAppState((s) => s.event.obsLabels);
   const isObs = useInObs();
+  const dispatch = useAppDispatch();
 
   return (
     <>
@@ -59,6 +60,9 @@ export function Dashboard() {
                 label={label}
                 value={value}
                 onEdit={() => setCurrentEdit(id)}
+                onDelete={() =>
+                  dispatch(eventSlice.actions.removeLabel({ id }))
+                }
               />
             ))}
           </CardList>
@@ -74,6 +78,7 @@ function LabelCard(props: {
   label: string;
   value: string;
   onEdit(this: void): void;
+  onDelete(this: void): void;
 }) {
   const href = useHref(routableGlobalSourcePath(props.id));
   return (
@@ -91,6 +96,19 @@ function LabelCard(props: {
             copyObsSource(new URL(href, document.location.href).href);
           }}
           href={href}
+        />
+        <Button
+          icon={<Trash />}
+          intent="danger"
+          onClick={() => {
+            if (
+              confirm(
+                `Delete the "${props.label}" text source? This cannot be undone.`,
+              )
+            ) {
+              props.onDelete();
+            }
+          }}
         />
       </ButtonGroup>
     </Card>


### PR DESCRIPTION
Uses the `confirm()` dialog to confirm before deleting.
<img width="949" height="201" alt="image" src="https://github.com/user-attachments/assets/4d78f422-c844-4720-ba72-7f4a1f6c3f15" />
<img width="589" height="279" alt="image" src="https://github.com/user-attachments/assets/e822b08d-c5f9-44ab-958f-aa85db835819" />
