### PR TITLE
Flag maimai DX CiRCLE/CiRCLE PLUS Asia-only songs as USA hidden

### DIFF
--- a/scripts/import-maimai.mts
+++ b/scripts/import-maimai.mts
@@ -250,7 +250,17 @@ task("Import MaiMai Data", async function ({ setStatus, setTitle, task }) {
     const patch = MAIMAI_PATCH[song.songId] || MAIMAI_PATCH[song.title];
     if (!patch) return song;
 
-    Object.assign(song, patch);
+    const { regions, ...songPatch } = patch;
+    Object.assign(song, songPatch);
+
+    // region availability lives on each sheet, so a patched value is applied
+    // to every sheet of the song
+    if (regions) {
+      song.sheets = (song.sheets as Array<any>).map((sheet) => ({
+        ...sheet,
+        regions: { ...sheet.regions, ...regions },
+      }));
+    }
 
     setStatus(`Applied patch for song: ${song.title ?? song.songId}`);
     return song;

--- a/scripts/maimai/maimai-patches.mjs
+++ b/scripts/maimai/maimai-patches.mjs
@@ -1,7 +1,8 @@
 /**
  * @file maimai-patch.mjs
  * Fields here will override/fill missing song info or chart info.
- * Overriding info for individual sheets is not supported currently.
+ * Overriding info for individual sheets is not supported currently, with the
+ * exception of `regions`, which is applied to every sheet of the song.
  */
 
 import { release } from "node:process";
@@ -99,5 +100,21 @@ export const MAIMAI_PATCH = {
   },
   サイエンス: {
     releaseDate: "2025-09-18",
+  },
+
+  // Songs present in the Asia release but hidden in the North American one.
+  // https://silentblue.remywiki.com/maimai_DX:CiRCLE_(Asia)
+  // https://silentblue.remywiki.com/maimai_DX:CiRCLE_PLUS_(Asia)
+  Overdose: {
+    regions: { jp: true, intl: true, usa: false },
+  },
+  "Colorful Starting Line": {
+    regions: { jp: true, intl: true, usa: false },
+  },
+  "Chasing destiny": {
+    regions: { jp: true, intl: true, usa: false },
+  },
+  "無敵的ハピネス！(SOS団5人Ver.)": {
+    regions: { jp: true, intl: true, usa: false },
   },
 };

--- a/src/songs/maimai.json
+++ b/src/songs/maimai.json
@@ -46176,23 +46176,32 @@
       "folder": "CiRCLE",
       "date_added": "2025-09-18",
       "charts": [
-        { "style": "single", "diffClass": "basic", "lvl": 1, "extras": ["dx"] },
+        {
+          "style": "single",
+          "diffClass": "basic",
+          "lvl": 1,
+          "flags": ["usa"],
+          "extras": ["dx"]
+        },
         {
           "style": "single",
           "diffClass": "advanced",
           "lvl": 6,
+          "flags": ["usa"],
           "extras": ["dx"]
         },
         {
           "style": "single",
           "diffClass": "expert",
           "lvl": 9.6,
+          "flags": ["usa"],
           "extras": ["dx"]
         },
         {
           "style": "single",
           "diffClass": "master",
           "lvl": 13,
+          "flags": ["usa"],
           "extras": ["dx"]
         }
       ]
@@ -48622,23 +48631,32 @@
       "folder": "CiRCLE PLUS",
       "date_added": "2026-03-19",
       "charts": [
-        { "style": "single", "diffClass": "basic", "lvl": 3, "extras": ["dx"] },
+        {
+          "style": "single",
+          "diffClass": "basic",
+          "lvl": 3,
+          "flags": ["usa"],
+          "extras": ["dx"]
+        },
         {
           "style": "single",
           "diffClass": "advanced",
           "lvl": 7,
+          "flags": ["usa"],
           "extras": ["dx"]
         },
         {
           "style": "single",
           "diffClass": "expert",
           "lvl": 10,
+          "flags": ["usa"],
           "extras": ["dx"]
         },
         {
           "style": "single",
           "diffClass": "master",
           "lvl": 13.2,
+          "flags": ["usa"],
           "extras": ["dx"]
         }
       ]
@@ -48651,23 +48669,32 @@
       "folder": "CiRCLE PLUS",
       "date_added": "2026-03-19",
       "charts": [
-        { "style": "single", "diffClass": "basic", "lvl": 4, "extras": ["dx"] },
+        {
+          "style": "single",
+          "diffClass": "basic",
+          "lvl": 4,
+          "flags": ["usa"],
+          "extras": ["dx"]
+        },
         {
           "style": "single",
           "diffClass": "advanced",
           "lvl": 7.6,
+          "flags": ["usa"],
           "extras": ["dx"]
         },
         {
           "style": "single",
           "diffClass": "expert",
           "lvl": 10.6,
+          "flags": ["usa"],
           "extras": ["dx"]
         },
         {
           "style": "single",
           "diffClass": "master",
           "lvl": 13.7,
+          "flags": ["usa"],
           "extras": ["dx"]
         }
       ]
@@ -48680,23 +48707,32 @@
       "folder": "CiRCLE PLUS",
       "date_added": "2026-03-19",
       "charts": [
-        { "style": "single", "diffClass": "basic", "lvl": 3, "extras": ["dx"] },
+        {
+          "style": "single",
+          "diffClass": "basic",
+          "lvl": 3,
+          "flags": ["usa"],
+          "extras": ["dx"]
+        },
         {
           "style": "single",
           "diffClass": "advanced",
           "lvl": 7,
+          "flags": ["usa"],
           "extras": ["dx"]
         },
         {
           "style": "single",
           "diffClass": "expert",
           "lvl": 10,
+          "flags": ["usa"],
           "extras": ["dx"]
         },
         {
           "style": "single",
           "diffClass": "master",
           "lvl": 13,
+          "flags": ["usa"],
           "extras": ["dx"]
         }
       ]


### PR DESCRIPTION
Overdose, Colorful Starting Line, Chasing destiny, and
無敵的ハピネス！(SOS団5人Ver.) are in the Asia release but not the North
American one, so they were drawing with "USA Ver. Hidden Songs" turned off.

The upstream database reports these sheets as available in every region, so
the import script's region-based flag logic never emitted a flag for them.
Mark their charts `usa` directly in the data file; correcting the import
side is left as follow-up work.

Fixes #644

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QPmjTL7Dr9uqh5ixQZaDvL