### PR TITLE
Event mode QoL improvements

### DIFF
--- a/src/assets/i18n.json
+++ b/src/assets/i18n.json
@@ -136,8 +136,8 @@
       "reset": "Reset"
     },
     "piuTourney": {
-      "explainer": "Pick a tournament from piu-tourney-maker to draw its upcoming matches. Read only — nothing is reported back.",
-      "idLabel": "tournament link or id (in the form of: /tourney/123)",
+      "explainer": "Link a tournament from {piuTmLink} to draw for upcoming matches. (Read only, cannot report back.)",
+      "idLabel": "tournament link or id",
       "save": "Save",
       "change": "change",
       "badId": "Expected a tournament link or a numeric id",

--- a/src/controls/draw-dialog.tsx
+++ b/src/controls/draw-dialog.tsx
@@ -1,6 +1,7 @@
 import {
   DialogBody,
   FormGroup,
+  HTMLSelect,
   Tabs,
   Tab,
   InputGroup,
@@ -12,12 +13,14 @@ import { MatchPicker, GauntletPicker, PickedMatch } from "../matches";
 import { StartggApiKeyGated } from "../startgg-gql/components";
 import { piuTourneyEnabled } from "../piu-tourney/config";
 import { createDraw } from "../state/thunks";
-import { useAppDispatch } from "../state/store";
+import { useAppDispatch, useAppState } from "../state/store";
+import { eventSlice } from "../state/event.slice";
 import { Player, SimpleMeta, newPlayer } from "../models/Drawing";
 import { lazy, Suspense, useState } from "react";
 import { useAppMode } from "../common-components/app-mode";
 import { DrawingMeta } from "../card-draw";
 import { useLastConfigSelected } from "../state/config.atoms";
+import { useLastCabSelected, useSetLastCabSelected } from "../state/cab.atoms";
 import { DelayedSpinner } from "../common-components/delayed-spinner";
 
 // keeps @supabase/supabase-js and the tourney maker UI out of the main bundle;
@@ -36,6 +39,16 @@ export function DrawDialog(props: Props) {
   const dispatch = useAppDispatch();
   const appMode = useAppMode();
   const [selectedTab, setSelectedTab] = useState<string | number>("custom");
+  const cabs = useAppState(eventSlice.selectors.allCabs);
+  const rememberedCab = useLastCabSelected();
+  const setRememberedCab = useSetLastCabSelected();
+  const showCabPicker = appMode === "event" && !!cabs.length;
+  // any client in the room can remove a cab, so a remembered id that no
+  // longer resolves falls back to not assigning rather than to a dead select
+  const cabId =
+    showCabPicker && cabs.some((cab) => cab.id === rememberedCab)
+      ? rememberedCab
+      : undefined;
 
   function handleExternalDraw(match: PickedMatch) {
     if (match.provider === "piu") {
@@ -64,7 +77,7 @@ export function DrawDialog(props: Props) {
       return;
     }
     props.onClose();
-    void dispatch(createDraw({ meta }, configId)).then((result) => {
+    void dispatch(createDraw({ meta }, configId, cabId)).then((result) => {
       props.onDrawAttempt(result === "ok");
     });
   }
@@ -74,6 +87,23 @@ export function DrawDialog(props: Props) {
       <FormGroup label="Config">
         <ConfigSelect selectedId={configId} onChange={setConfigId} />
       </FormGroup>
+      {showCabPicker && (
+        <FormGroup label="Assign to cab">
+          <HTMLSelect
+            value={cabId || ""}
+            onChange={(e) =>
+              setRememberedCab(e.currentTarget.value || undefined)
+            }
+          >
+            <option value="">don't assign</option>
+            {cabs.map((cab) => (
+              <option key={cab.id} value={cab.id}>
+                {cab.name}
+              </option>
+            ))}
+          </HTMLSelect>
+        </FormGroup>
+      )}
       <Tabs
         id="new-draw"
         selectedTabId={selectedTab}

--- a/src/hooks/useIntl.ts
+++ b/src/hooks/useIntl.ts
@@ -7,6 +7,7 @@ export function useIntl() {
   const { formatMessage } = useReactIntl();
   return useMemo(
     () => ({
+      formatMessage,
       t: (
         id: string,
         values?: Record<string, Primitive>,

--- a/src/piu-tourney/components.tsx
+++ b/src/piu-tourney/components.tsx
@@ -1,4 +1,11 @@
-import { Button, Callout, InputGroup, Label, Text } from "@blueprintjs/core";
+import {
+  Button,
+  Callout,
+  InputGroup,
+  Label,
+  Link,
+  Text,
+} from "@blueprintjs/core";
 import { Edit } from "@blueprintjs/icons";
 import { useAtom } from "jotai";
 import React, { ReactNode, useCallback, useRef, useState } from "react";
@@ -37,7 +44,7 @@ export function PiuTourneyGated(props: { children: ReactNode }) {
  * tournament, and remembers it for this device.
  */
 export function PiuTourneyPicker() {
-  const { t } = useIntl();
+  const { t, formatMessage } = useIntl();
   const [tourneyId, setTourneyId] = useAtom(piuTourneyIdAtom);
   const [parseError, setParseError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -86,22 +93,25 @@ export function PiuTourneyPicker() {
   return (
     <form onSubmit={save}>
       <Text tagName="p">
-        {t(
-          "piuTourney.explainer",
-          undefined,
-          "Pick a tournament from piu-tourney-maker to draw its upcoming matches. Read only — nothing is reported back.",
+        {formatMessage(
+          {
+            id: "piuTourney.explainer",
+          },
+          {
+            piuTmLink: (
+              <Link href="https://piu-tourney-maker.vercel.app/">
+                piu-tourney-maker
+              </Link>
+            ),
+          },
         )}
       </Text>
       <Label>
-        {t(
-          "piuTourney.idLabel",
-          undefined,
-          "tournament link or id (in the form of: /tourney/123)",
-        )}
+        {t("piuTourney.idLabel")}
         <InputGroup
           defaultValue={tourneyId ? String(tourneyId) : undefined}
           inputRef={inputRef}
-          placeholder="https://…/tourney/123"
+          placeholder="https://piu-tourney-maker.vercel.app/tourney/123"
           rightElement={
             <Button type="submit">
               {t("piuTourney.save", undefined, "Save")}

--- a/src/startgg-gql/components.tsx
+++ b/src/startgg-gql/components.tsx
@@ -1,7 +1,19 @@
-import { Button, Classes, InputGroup, Label, Text } from "@blueprintjs/core";
+import {
+  Button,
+  Callout,
+  Classes,
+  InputGroup,
+  Label,
+  Text,
+} from "@blueprintjs/core";
 import { useAtomValue, useAtom, useSetAtom } from "jotai";
-import React, { ReactNode, useRef, useCallback } from "react";
-import { startggKeyAtom, startggEventSlug, useCurrentUserEvents } from ".";
+import React, { ReactNode, useRef, useState, useCallback } from "react";
+import {
+  startggKeyAtom,
+  startggEventSlug,
+  parseEventSlug,
+  useCurrentUserEvents,
+} from ".";
 
 export function StartggApiKeyGated(props: { children: ReactNode }) {
   const apiKey = useAtomValue(startggKeyAtom);
@@ -16,15 +28,36 @@ export function StartggApiKeyGated(props: { children: ReactNode }) {
 export function StartggCredsManager() {
   const [apiKey, setApiKey] = useAtom(startggKeyAtom);
   const [eventSlug, setEventSlug] = useAtom(startggEventSlug);
+  const [slugError, setSlugError] = useState<string | null>(null);
   const apikeyRef = useRef<HTMLInputElement>(null);
   const slugRef = useRef<HTMLInputElement>(null);
   const saveKey = useCallback(
     async (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       if (!apikeyRef.current) return;
-      setApiKey(apikeyRef.current.value);
+      // tokens get pasted, and a stray newline makes every request 401
+      setApiKey(apikeyRef.current.value.trim());
       if (!slugRef.current) return;
-      setEventSlug(slugRef.current.value);
+      const raw = slugRef.current.value;
+      if (!raw.trim()) {
+        // the field is disabled until a key is saved, so a blank slug on the
+        // first save is the normal path, not a mistake worth shouting about
+        setSlugError(null);
+        setEventSlug(null);
+        return;
+      }
+      const slug = parseEventSlug(raw);
+      if (!slug) {
+        setSlugError(
+          "Expected an event address like tournament/SOMETHING/event/SOMETHING",
+        );
+        return;
+      }
+      setSlugError(null);
+      // show what actually got saved, since a pasted URL loses its origin and
+      // any trailing path here
+      slugRef.current.value = slug;
+      setEventSlug(slug);
     },
     [setApiKey, setEventSlug],
   );
@@ -51,17 +84,22 @@ export function StartggCredsManager() {
         <pre style={{ display: "inline" }}>
           tournament/SOMETHING/event/SOMETHING
         </pre>
-        )
+        ) — pasting the whole event page address works too
         <InputGroup
           disabled={!apiKey}
           defaultValue={eventSlug || undefined}
           inputRef={slugRef}
+          intent={slugError ? "danger" : "none"}
+          placeholder="https://start.gg/tournament/SOMETHING/event/SOMETHING"
+          onChange={() => setSlugError(null)}
           rightElement={<Button type="submit">Save</Button>}
         />
       </Label>
+      {slugError && <Callout intent="danger">{slugError}</Callout>}
       {!!apiKey && (
         <EventPicker
           onSelected={(slug) => {
+            setSlugError(null);
             if (slugRef.current) {
               slugRef.current.value = slug;
             }

--- a/src/startgg-gql/components.tsx
+++ b/src/startgg-gql/components.tsx
@@ -8,6 +8,7 @@ import {
 } from "@blueprintjs/core";
 import { useAtomValue, useAtom, useSetAtom } from "jotai";
 import React, { ReactNode, useRef, useState, useCallback } from "react";
+import { DelayedSpinner } from "../common-components/delayed-spinner";
 import {
   startggKeyAtom,
   startggEventSlug,
@@ -114,6 +115,7 @@ function EventPicker(props: { onSelected(slug: string): void }) {
   const [result] = useCurrentUserEvents();
   const setEventSlug = useSetAtom(startggEventSlug);
   const tournaments = result.data?.currentUser?.tournaments?.nodes;
+  const pageInfo = result.data?.currentUser?.tournaments?.pageInfo;
 
   function handleSelect(e: React.MouseEvent<HTMLAnchorElement>) {
     e.preventDefault();
@@ -124,12 +126,36 @@ function EventPicker(props: { onSelected(slug: string): void }) {
     }
   }
 
-  if (!tournaments) {
+  if (result.error) {
+    // an expired or mistyped token lands here, and rendering nothing for it
+    // left the picker simply absent with no hint as to why
+    return (
+      <Callout intent="danger">
+        Couldn't load your tournaments: {result.error.message}
+      </Callout>
+    );
+  }
+  if (result.fetching && !tournaments) {
+    return <DelayedSpinner />;
+  }
+  if (!tournaments?.length) {
     return null;
   }
+  const total = pageInfo?.total ?? tournaments.length;
   return (
     <>
-      <p>Try the easy way and pick from your tournaments:</p>
+      <p>
+        Try the easy way and pick from your tournaments:
+        {total > tournaments.length && (
+          <>
+            {" "}
+            <span className={Classes.TEXT_MUTED}>
+              newest {tournaments.length} of {total} — paste the slug above for
+              an older one
+            </span>
+          </>
+        )}
+      </p>
       <ul className={Classes.LIST}>
         {tournaments.map((t) => {
           if (!t) return null;

--- a/src/startgg-gql/index.ts
+++ b/src/startgg-gql/index.ts
@@ -25,6 +25,31 @@ export const startggEventSlug = atomWithStorage<string | null>(
   { getOnInit: true },
 );
 
+/**
+ * Accepts a start.gg event URL or a bare `tournament/x/event/y` slug and
+ * returns just the two-segment pair the API takes as an event slug.
+ *
+ * Everything past the event is dropped, since the address bar is where these
+ * get copied from and it's rarely sitting on the bare event page —
+ * `…/event/singles/brackets/1234/5678` and `…/event/singles/overview` both
+ * come back as `tournament/foo/event/singles`. Returns null when there's no
+ * event slug in there to find, so the caller can say so rather than saving a
+ * slug every query will 404 on.
+ */
+export function parseEventSlug(raw: string): string | null {
+  const match = raw
+    .trim()
+    // an origin, if pasted as a full URL. The scheme is optional because
+    // copying a link out of running text tends to lose it.
+    .replace(/^(?:https?:)?\/\//i, "")
+    .replace(/^(?:www\.)?(?:start|smash)\.gg/i, "")
+    // neither a query string nor a fragment is ever part of the slug
+    .replace(/[?#].*$/, "")
+    .match(/^\/?tournament\/([\w-]+)\/event\/([\w-]+)(?:\/|$)/i);
+  if (!match) return null;
+  return `tournament/${match[1]}/event/${match[2]}`;
+}
+
 export const urqlClient = new Client({
   url: "https://api.start.gg/gql/alpha",
   fetchOptions: () => ({

--- a/src/startgg-gql/index.ts
+++ b/src/startgg-gql/index.ts
@@ -227,6 +227,11 @@ const EventListQuery: typeof EventListDocument = gql`
           page: $page
           perPage: $perPage
           filter: { tournamentView: "admin" }
+          # only the first page is ever fetched, so the sort decides which
+          # tournaments are reachable at all. Default order buries a TO with
+          # a long history under events from years ago, hiding the one they
+          # are running this weekend.
+          sortBy: "startAt desc"
         }
       ) {
         nodes {

--- a/src/state/cab.atoms.ts
+++ b/src/state/cab.atoms.ts
@@ -1,0 +1,27 @@
+import { useAtomValue, useSetAtom } from "jotai";
+import { atomFamily, atomWithStorage } from "jotai/utils";
+import { useRoomName } from "../hooks/useRoomName";
+
+/**
+ * Which cab new draws get assigned to, if any. Device-local and per-room like
+ * the last config selected, rather than synced through partykit: two laptops
+ * running the same event each want the cab sitting in front of them.
+ */
+const lastCabSelectedByEvent = atomFamily((roomName: string) =>
+  atomWithStorage<string | undefined>(
+    `ddrtools.lastCabSelected:${roomName}`,
+    undefined,
+    undefined,
+    { getOnInit: true },
+  ),
+);
+
+export function useLastCabSelected() {
+  const roomName = useRoomName();
+  return useAtomValue(lastCabSelectedByEvent(roomName));
+}
+
+export function useSetLastCabSelected() {
+  const roomName = useRoomName();
+  return useSetAtom(lastCabSelectedByEvent(roomName));
+}

--- a/src/state/thunks.ts
+++ b/src/state/thunks.ts
@@ -10,6 +10,7 @@ import {
   SubDrawing,
 } from "../models/Drawing";
 import { configSlice, ConfigState, defaultConfig } from "./config.slice";
+import { eventSlice } from "./event.slice";
 
 declare const umami: {
   track(
@@ -29,11 +30,13 @@ function trackDraw(count: number | null, game?: string) {
 
 /**
  * Thunk creator for performing a new draw
+ * @param assignToCabId if given, the finished draw is put up on that cab
  * @returns false if draw was unsuccessful
  */
 export function createDraw(
   drawMeta: DrawingMeta,
   configId: string,
+  assignToCabId?: string,
 ): AppThunk<Promise<"nok" | "ok">> {
   return async (dispatch, getState) => {
     const state = getState();
@@ -110,6 +113,18 @@ export function createDraw(
     }
 
     dispatch(drawingsSlice.actions.addDrawing(drawing));
+    // the whole match rather than the set it starts with, so the cab keeps
+    // following it through an extra draw or a merge. Re-read state here
+    // because the draw above is async and any client in the room could have
+    // removed the cab in the meantime.
+    if (assignToCabId && getState().event.cabs[assignToCabId]) {
+      dispatch(
+        eventSlice.actions.assignMatchToCab({
+          cabId: assignToCabId,
+          matchId: drawing.id,
+        }),
+      );
+    }
     return "ok";
   };
 }

--- a/src/tournament-mode/main-view.tsx
+++ b/src/tournament-mode/main-view.tsx
@@ -39,7 +39,7 @@ export function MainView() {
         Eligible Charts
       </Tab>
       <Tab id="players" panel={<PlayerNamesControls />}>
-        Start.gg Sync
+        3rd Party Sync
       </Tab>
     </Tabs>
   );


### PR DESCRIPTION
- Better validation for start.gg event slugs (trims trailing path segments)
- For the list of tournaments you have admin access over, the newest ones are sorted first now
- New option to immediately assign a draw to a cab in the draw dialog